### PR TITLE
add a linting step to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,4 +15,5 @@ jobs:
           node-version: '12.21.0'
       - run: yarn install
       - run: yarn build
+      - run: yarn lint
       - run: yarn test


### PR DESCRIPTION
Now lint errors will break the build. I checked and the exit code for just warnings is 0, so it should _only_ break for errors.