### PR TITLE
Header component: use context vars instead of props

### DIFF
--- a/ui/src/Reader.tsx
+++ b/ui/src/Reader.tsx
@@ -16,9 +16,7 @@ import { PageWrapper } from './library/components/PageWrapper';
 import { DocumentContext } from './library/context/DocumentContext';
 import { TransformContext } from './library/context/TransformContext';
 import { UiContext } from './library/context/UiContext';
-import { rotateClockwise, rotateCounterClockwise } from './library/rotate';
 import { computePageSize } from './library/scale';
-import { scrollTo } from './library/scroll';
 
 export const Reader: React.FunctionComponent<RouteComponentProps> = () => {
   const TEST_PDF_URL = 'https://arxiv.org/pdf/math/0008020v2.pdf';
@@ -29,63 +27,10 @@ export const Reader: React.FunctionComponent<RouteComponentProps> = () => {
   // ref for the scrollable region where the pages are rendered
   const pdfScrollableRef = React.createRef<HTMLDivElement>();
 
-  const {
-    isShowingHighlightOverlay,
-    isShowingTextHighlight,
-    setErrorMessage,
-    setIsLoading,
-    setIsShowingHighlightOverlay,
-    setIsShowingOutline,
-    setIsShowingTextHighlight,
-  } = React.useContext(UiContext);
-  const { rotation, scale, setRotation } = React.useContext(TransformContext);
+  const { isShowingHighlightOverlay, isShowingTextHighlight, setErrorMessage, setIsLoading } =
+    React.useContext(UiContext);
+  const { rotation, scale } = React.useContext(TransformContext);
   const { numPages, pageSize, setNumPages, setPageSize } = React.useContext(DocumentContext);
-
-  function handleShowOutline(): void {
-    setIsShowingOutline(true);
-  }
-
-  function handleRotateCW(): void {
-    setRotation(rotateClockwise(rotation));
-  }
-
-  function handleRotateCCW(): void {
-    setRotation(rotateCounterClockwise(rotation));
-  }
-
-  // TODO: #29079 remove this once UI design is finalized
-  function handleToggleHighlightOverlay(): void {
-    // Store new value in a temp variable because state value updates are batched and
-    // executed once this function returns. Otherwise we won't get the correct value
-    // for isShowingHighlightOverlay down below
-    const newVal = !isShowingHighlightOverlay;
-    setIsShowingHighlightOverlay(newVal);
-
-    if (newVal) {
-      setIsShowingTextHighlight(false);
-    }
-  }
-
-  // TODO: #29079 remove this once UI design is finalized
-  function handleToggleTextHighlight(): void {
-    // Store new value in a temp variable because state value updates are batched and
-    // executed once this function returns. Otherwise we won't get the correct value
-    // for isShowingTextHighlight down below
-    const newVal = !isShowingTextHighlight;
-    setIsShowingTextHighlight(newVal);
-    if (newVal) {
-      setIsShowingHighlightOverlay(false);
-    }
-  }
-
-  // TODO: #29079 remove this once UI design is finalized and we have real data
-  function handleScrollToFigure(): void {
-    setIsShowingTextHighlight(false);
-    setIsShowingHighlightOverlay(false);
-
-    const id = 'demoFigure_1';
-    scrollTo(id);
-  }
 
   function onPdfLoadSuccess(pdfDoc: PDFDocumentProxy): void {
     // getPage uses 1-indexed pageNumber, not 0-indexed pageIndex
@@ -224,14 +169,7 @@ export const Reader: React.FunctionComponent<RouteComponentProps> = () => {
       <Route path="/">
         <div className="reader__container">
           <div className="reader__header">
-            <Header
-              handleShowOutline={handleShowOutline}
-              handleRotateCW={handleRotateCW}
-              handleRotateCCW={handleRotateCCW}
-              handleToggleHighlightOverlay={handleToggleHighlightOverlay}
-              handleToggleHighlightText={handleToggleTextHighlight}
-              handleScrollToFigure={handleScrollToFigure}
-            />
+            <Header />
           </div>
           <DocumentWrapper
             className="reader__main"

--- a/ui/src/components/Header.tsx
+++ b/ui/src/components/Header.tsx
@@ -1,42 +1,89 @@
 import * as React from 'react';
 
+import { TransformContext } from '../library/context/TransformContext';
+import { UiContext } from '../library/context/UiContext';
+import { rotateClockwise, rotateCounterClockwise } from '../library/rotate';
+import { scrollTo } from '../library/scroll';
 import { SimpleZoomControl } from './SimpleZoomControl';
 
-// TODO: #28926 Update handlers to use context vars instead of props
-type Props = {
-  handleToggleHighlightOverlay: () => void;
-  handleToggleHighlightText: () => void;
-  handleShowOutline: () => void;
-  handleRotateCW: () => void;
-  handleRotateCCW: () => void;
-  handleScrollToFigure: () => void;
-};
+export const Header: React.FunctionComponent = () => {
+  const {
+    isShowingHighlightOverlay,
+    isShowingTextHighlight,
+    setIsShowingHighlightOverlay,
+    setIsShowingOutline,
+    setIsShowingTextHighlight,
+  } = React.useContext(UiContext);
+  const { rotation, setRotation } = React.useContext(TransformContext);
 
-export class Header extends React.PureComponent<Props> {
-  render(): React.ReactNode {
-    return (
-      <div className="reader__header">
-        <div className="header-control">
-          <SimpleZoomControl />
-        </div>
-        <div className="header-control">
-          Rotate
-          <a onClick={this.props.handleRotateCW}>↷</a>
-          <a onClick={this.props.handleRotateCCW}>↶</a>
-        </div>
-        <div className="header-control">
-          <a onClick={this.props.handleShowOutline}>Outline</a>
-        </div>
-        <div className="header-control">
-          <a onClick={this.props.handleToggleHighlightOverlay}>Highlight Overlay</a>
-        </div>
-        <div className="header-control">
-          <a onClick={this.props.handleToggleHighlightText}>Highlight Text</a>
-        </div>
-        <div className="header-control">
-          <a onClick={this.props.handleScrollToFigure}>Scroll to Figure 1</a>
-        </div>
-      </div>
-    );
+  function handleShowOutline(): void {
+    setIsShowingOutline(true);
   }
-}
+
+  function handleRotateCW(): void {
+    setRotation(rotateClockwise(rotation));
+  }
+
+  function handleRotateCCW(): void {
+    setRotation(rotateCounterClockwise(rotation));
+  }
+
+  // TODO: #29079 remove this once UI design is finalized
+  function handleToggleHighlightOverlay(): void {
+    // Store new value in a temp variable because state value updates are batched and
+    // executed once this function returns. Otherwise we won't get the correct value
+    // for isShowingHighlightOverlay down below
+    const newVal = !isShowingHighlightOverlay;
+    setIsShowingHighlightOverlay(newVal);
+
+    if (newVal) {
+      setIsShowingTextHighlight(false);
+    }
+  }
+
+  // TODO: #29079 remove this once UI design is finalized
+  function handleToggleTextHighlight(): void {
+    // Store new value in a temp variable because state value updates are batched and
+    // executed once this function returns. Otherwise we won't get the correct value
+    // for isShowingTextHighlight down below
+    const newVal = !isShowingTextHighlight;
+    setIsShowingTextHighlight(newVal);
+    if (newVal) {
+      setIsShowingHighlightOverlay(false);
+    }
+  }
+
+  // TODO: #29079 remove this once UI design is finalized and we have real data
+  function handleScrollToFigure(): void {
+    setIsShowingTextHighlight(false);
+    setIsShowingHighlightOverlay(false);
+
+    const id = 'demoFigure_1';
+    scrollTo(id);
+  }
+
+  return (
+    <div className="reader__header">
+      <div className="header-control">
+        <SimpleZoomControl />
+      </div>
+      <div className="header-control">
+        Rotate
+        <a onClick={handleRotateCW}>↷</a>
+        <a onClick={handleRotateCCW}>↶</a>
+      </div>
+      <div className="header-control">
+        <a onClick={handleShowOutline}>Outline</a>
+      </div>
+      <div className="header-control">
+        <a onClick={handleToggleHighlightOverlay}>Highlight Overlay</a>
+      </div>
+      <div className="header-control">
+        <a onClick={handleToggleTextHighlight}>Highlight Text</a>
+      </div>
+      <div className="header-control">
+        <a onClick={handleScrollToFigure}>Scroll to Figure 1</a>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Description

This is a subtask of https://github.com/allenai/scholar/issues/28926 and a continuation of the state management work from https://github.com/allenai/scholar/issues/28332. The goal of this task was to update our new context variables directly from the `Header`'s click handlers instead of passing update functions in as props from `Reader`.

Changes in this PR:
- Remove all props from `Header` component
- Move click handler functions from `Reader` into `Header`


## Reviewer Instructions

This is one of those tasks that got split out from my giant state management PR. 

Reworking some of these click handlers to prevent re-renders is part of my [cleanup ticket](https://github.com/allenai/scholar/issues/28926).


## Testing Plan

- Manual testing:
  - Existing header links still work as expected: zoom in/out, rotate CW/CCW, outline, highlight overlay, highlight text, scroll to figure 1
- Run all unit tests


## Demo

![](http://g.recordit.co/t4Ev4T7J51.gif)