### PR TITLE
28926 PDF Loose Ends- PageWrapper component uses context variables

### DIFF
--- a/ui/src/Reader.tsx
+++ b/ui/src/Reader.tsx
@@ -14,9 +14,9 @@ import { DocumentWrapper } from './library/components/DocumentWrapper';
 import { Overlay } from './library/components/Overlay';
 import { PageWrapper } from './library/components/PageWrapper';
 import { DocumentContext } from './library/context/DocumentContext';
-import { TransformContext } from './library/context/TransformContext';
 
 export const Reader: React.FunctionComponent<RouteComponentProps> = () => {
+  const { numPages } = React.useContext(DocumentContext);
   const TEST_PDF_URL = 'https://arxiv.org/pdf/math/0008020v2.pdf';
 
   // ref for the div in which the Document component renders
@@ -24,9 +24,6 @@ export const Reader: React.FunctionComponent<RouteComponentProps> = () => {
 
   // ref for the scrollable region where the pages are rendered
   const pdfScrollableRef = React.createRef<HTMLDivElement>();
-
-  const { rotation, scale } = React.useContext(TransformContext);
-  const { numPages, pageSize } = React.useContext(DocumentContext);
 
   return (
     <BrowserRouter>
@@ -39,12 +36,7 @@ export const Reader: React.FunctionComponent<RouteComponentProps> = () => {
             <Outline parentRef={pdfContentRef} />
             <div className="reader__page-list" ref={pdfScrollableRef}>
               {Array.from({ length: numPages }).map((_, i) => (
-                <PageWrapper
-                  key={i}
-                  pageIndex={i}
-                  scale={scale}
-                  rotation={rotation}
-                  pageSize={pageSize}>
+                <PageWrapper key={i} pageIndex={i}>
                   <Overlay>
                     <HighlightOverlayDemo pageIndex={i} />
                     <TextHighlightDemo pageIndex={i} />

--- a/ui/src/library/components/PageWrapper.tsx
+++ b/ui/src/library/components/PageWrapper.tsx
@@ -2,10 +2,10 @@ import * as React from 'react';
 import { Page } from 'react-pdf/dist/esm/entry.webpack';
 import { RenderFunction } from 'react-pdf/dist/Page';
 
-import { isSideways, PageRotation } from '../rotate';
-import { Size } from '../scale';
+import { DocumentContext } from '../context/DocumentContext';
+import { TransformContext } from '../context/TransformContext';
+import { isSideways } from '../rotate';
 import { generatePageId } from '../scroll';
-import { Nullable } from '../types';
 import { HighlightOverlay } from './HighlightOverlay';
 import { Overlay } from './Overlay';
 
@@ -18,69 +18,64 @@ type PageProps = {
   noData?: string | React.ReactElement | RenderFunction;
   pageIndex?: number;
   pageNumber?: number;
-  scale: number; // Unlike the react-pdf component, this is now required
-  rotation: PageRotation;
 };
 type Props = {
   className?: string;
   children?: React.ReactElement<typeof HighlightOverlay | typeof Overlay>;
-  pageSize?: Nullable<Size>;
 } & PageProps;
 
-export class PageWrapper extends React.PureComponent<Props> {
-  onClick = (e: unknown): void => {
-    console.log(e);
-  };
+export const PageWrapper: React.FunctionComponent<Props> = ({
+  children,
+  error,
+  loading,
+  noData,
+  pageIndex,
+  pageNumber,
+}: Props) => {
+  const { rotation, scale } = React.useContext(TransformContext);
+  const { pageSize } = React.useContext(DocumentContext);
 
-  computeStyle = (): { width: number } | undefined => {
-    const { pageSize, scale, rotation } = this.props;
+  // Don't display until we have page size data
+  // TODO: Handle this nicer so we display either the loading or error treatment
+  if (!pageSize) {
+    return null;
+  }
+
+  function onClick(e: unknown): void {
+    console.log(e);
+  }
+
+  function computeStyle(): { width: number } | undefined {
     if (!pageSize) {
       return undefined;
     }
     return {
       width: (isSideways(rotation) ? pageSize.height : pageSize.width) * scale,
     };
-  };
-
-  render(): React.ReactNode {
-    const { pageSize, error, loading, noData, pageIndex, pageNumber, scale, rotation, children } =
-      this.props;
-    // Click events from the Outline only give pageNumber, so we need to be clever when setting the ID.
-    // TODO: Settle on one to use--pageIndex or pageNumber. react-pdf seems to prefer the latter
-    const pageNumberForId = this.props.pageNumber
-      ? this.props.pageNumber
-      : this.props.pageIndex
-      ? this.props.pageIndex + 1
-      : 1;
-
-    // Don't display until we have page size data
-    // TODO: Handle this nicer so we display either the loading or error treatment
-    if (!pageSize) {
-      return null;
-    }
-
-    // Width needs to be set to prevent the outermost Page div from extending to fit the parent,
-    // and mis-aligning the text layer.
-    // TODO: Can we CSS this to auto-shrink?
-    return (
-      <div
-        id={generatePageId(pageNumberForId)}
-        className="reader__page"
-        style={this.computeStyle()}>
-        {children}
-        <Page
-          width={isSideways(rotation) ? pageSize.height : pageSize.width}
-          error={error}
-          loading={loading}
-          noData={noData}
-          pageIndex={pageIndex}
-          pageNumber={pageNumber}
-          scale={scale}
-          onClick={this.onClick}
-          rotate={rotation}
-          renderAnnotationLayer={false}
-        />
-      </div>
-    );
   }
-}
+
+  // Click events from the Outline only give pageNumber, so we need to be clever when setting the ID.
+  // TODO: #28926 subtask- Settle on one to use--pageIndex or pageNumber. react-pdf seems to prefer the latter
+  const pageNumberForId = pageNumber ? pageNumber : pageIndex ? pageIndex + 1 : 1;
+
+  // Width needs to be set to prevent the outermost Page div from extending to fit the parent,
+  // and mis-aligning the text layer.
+  // TODO: Can we CSS this to auto-shrink?
+  return (
+    <div id={generatePageId(pageNumberForId)} className="reader__page" style={computeStyle()}>
+      {children}
+      <Page
+        width={isSideways(rotation) ? pageSize.height : pageSize.width}
+        error={error}
+        loading={loading}
+        noData={noData}
+        pageIndex={pageIndex}
+        pageNumber={pageNumber}
+        scale={scale}
+        onClick={onClick}
+        rotate={rotation}
+        renderAnnotationLayer={false}
+      />
+    </div>
+  );
+};


### PR DESCRIPTION
## Description

This covers the `PageWrapper` component subtask of https://github.com/allenai/scholar/issues/28926

Changes in this PR:
- Turned `PageWrapper` into a function component
- Updated `PageWrapper` component to use context vars instead of props for `scale`, `rotation`, and `pageSize`

## Testing Plan

- Manual testing: tested zoom in/out, rotation, outline, highlight overlay, text highlight, and scroll to figure 1
- Ran all unit tests