### PR TITLE
Fix mis-alignment of PDF contents

### DIFF
--- a/ui/demo/less/reader.less
+++ b/ui/demo/less/reader.less
@@ -99,8 +99,3 @@ body {
     font-weight: 300;
   }
 }
-
-// HACK: avoid text mis-alignment
-.react-pdf__Page__textContent>span {
-  height: 0em!important;
-}

--- a/ui/library/less/styles.less
+++ b/ui/library/less/styles.less
@@ -24,3 +24,9 @@
   position: absolute;
   z-index: @z-index-bbox-overlay;
 }
+
+
+// HACK: avoid mis-alignment of selected texts
+.react-pdf__Page__textContent>span {
+  height: 0em!important;
+}


### PR DESCRIPTION
## Description
https://github.com/allenai/scholar/issues/29678

The situation was made intentionally by the author of react-pdf library: https://github.com/wojtekmaj/react-pdf/issues/332#issuecomment-469037713

## Solution
I tried adding a custom function by setting `<Page ... onLoadSuccess={adjustTextLayer}> ... </Page>` to reset the styles of spans that wrap the texts but didn't work. So I ended up forcing height to be 0 by using `!important` flag.

## Before
<img width="969" alt="Screen Shot 2021-12-07 at 13 36 28" src="https://user-images.githubusercontent.com/84034381/145111118-5c6df278-5555-4af6-b44d-0d30dd3b0b80.png">

## After
<img width="976" alt="Screen Shot 2021-12-07 at 13 37 01" src="https://user-images.githubusercontent.com/84034381/145111143-a3b1fa2b-cc5a-4743-8cd6-46f70b347a92.png">


## More thoughts
The texts are still not fully aligned which is probably because the font families and sizes between the red and the black are different. Would we like them to be the same?