### PR TITLE
Use new pdf sample for demo reader app

### DIFF
--- a/ui/demo/components/Reader.tsx
+++ b/ui/demo/components/Reader.tsx
@@ -25,9 +25,9 @@ export const Reader: React.FunctionComponent<RouteComponentProps> = () => {
   // ref for the scrollable region where the pages are rendered
   const pdfScrollableRef = React.createRef<HTMLDivElement>();
 
-  const samplePdfUrl = 'https://arxiv.org/pdf/2111.05685.pdf';
+  const samplePdfUrl = 'https://arxiv.org/pdf/2112.07873.pdf';
   const sampleS2airsUrl =
-    'http://s2airs.dev.s2.allenai.org/v1/pdf_data?pdf_sha=ed1b1acd7a36b22397f052d10426f1531cfc18ce';
+    'http://s2airs.prod.s2.allenai.org/v1/pdf_data?pdf_sha=9b79eb8d21c8a832daedbfc6d8c31bebe0da3ed5';
 
   React.useEffect(() => {
     // If data has been loaded then return directly to prevent sending multiple requests


### PR DESCRIPTION
https://github.com/allenai/pdf-component-library/issues/70
The original sample pdf has no outlines, so it is replaced with a new one.

Outlines:
<img width="1471" alt="Screen Shot 2022-01-12 at 17 50 46" src="https://user-images.githubusercontent.com/84034381/149251498-b85203f4-bbb8-4aee-8594-7be3263b5c90.png">

Citations:
<img width="1473" alt="Screen Shot 2022-01-12 at 17 50 57" src="https://user-images.githubusercontent.com/84034381/149251519-ad4fd8d4-299d-4237-aa0f-be35705216a9.png">

