### PR TITLE
Updated node version to v12.22.6

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -2,7 +2,7 @@
 # environment where the JavaScript build process can run. In production the
 # files built by this process are served from disk, while in development a HTTP
 # server that's distributed with the UI build tools is used.
-FROM node:14.15.1
+FROM node:12.22.6
 
 # Setup a spot for our code
 WORKDIR /usr/local/src/skiff/app/ui


### PR DESCRIPTION
For ticket [#29404](https://github.com/allenai/scholar/issues/29404).

Updated Docker node version to v12.22.6. No need to updated GitHub build because it has been at v12.22.6 for awhile.