### PR TITLE
add a test pdf worker version

### DIFF
--- a/ui/library/test/utils/pdfWorker.test.ts
+++ b/ui/library/test/utils/pdfWorker.test.ts
@@ -1,0 +1,13 @@
+import { expect } from 'chai';
+import { pdfjs } from 'react-pdf';
+
+import { initPdfWorker } from '../../src/utils/pdfWorker';
+
+describe('initPdfWorker', () => {
+  it('pdf worker CDN matches the check in pingdom.com', () => {
+    initPdfWorker();
+    expect(pdfjs.GlobalWorkerOptions.workerSrc).to.equal(
+      '//cdnjs.cloudflare.com/ajax/libs/pdf.js/2.6.347/pdf.worker.min.js'
+    );
+  });
+});


### PR DESCRIPTION
As part of https://github.com/allenai/scholar/issues/30552, added a pingdom check for url
`https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.6.347/pdf.worker.min.js`

Adding a test to make sure we update the pingdom url if we upgrade the version of pdfjs
