### PR TITLE
Incremented library version number to v0.0.8

### DIFF
--- a/ui/library/dist/package.json
+++ b/ui/library/dist/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@allenai/pdf-components",
-    "version": "0.0.5",
+    "version": "0.0.8",
     "license": "Apache-2.0",
     "author": "s2@allenai.org",
     "main": "./pdf-components.js",


### PR DESCRIPTION
Note: old version number in `package.json` was v0.0.5, but v0.0.6/0.0.7 were not available because the team used them for practicing npm publishing. So, the next available version number is v0.0.8.