### PR TITLE
pass the renderAnnotations as a prop. Include the required styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,20 @@ installed on your local machine.
 
 ## License
 This project is licensed under the Apache License 2.0.
+
+## User guide
+### DocumentWrapper
+TODO
+
+### PageWrapper
+Displays a page. Should be placed inside `<DocumentWrapper />`. Alternatively, it can have `pdf` prop passed, which can be obtained from `<DocumentWrapper />`'s `onLoadSuccess` callback function, however some advanced functions like linking between pages inside a document may not be working correctly.
+
+#### Props
+| Prop name               | Description                                                                                                                                                                                                                                                                                      | Default value                                 | Example values                                                                                                                                                                                                                                                                                   |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| className          | Class name(s) that will be added to rendered element along with the default.                                                        | n/a                                                   | <ul><li>String:<br />`"custom-class-name-1 custom-class-name-2"`</li><li>Array of strings:<br />`["custom-class-name-1", "custom-class-name-2"]`</li></ul>|
+| error                   | What the component should display in case of an error.                                                          | `"Failed to load the page."`                  | <ul><li>String:<br />`"An error occurred!"`</li><li>React element:<br />`<div>An error occurred!</div>`</li><li>Function:<br />`this.renderError`</li></ul>|
+ loading                 | What the component should display while loading.                                                       | `"Loading page…"`                             | <ul><li>String:<br />`"Please wait!"`</li><li>React element:<br />`<div>Please wait!</div>`</li><li>Function:<br />`this.renderLoader`</li></ul>|
+ | noData                  | What the component should display in case of no data.                                                          | `"No page specified."`                        | <ul><li>String:<br />`"Please select a page."`</li><li>React element:<br />`<div>Please select a page.</div>`</li><li>Function:<br />`this.renderNoData`</li></ul>|
+ | pageIndex               | Which page from PDF file should be displayed, by page index.| `0`                                           | `1` |
+ | renderAnnotationLayer   | Whether annotations (e.g. links) should be rendered.                                                      | `true`                                        | `false`|

--- a/ui/library/less/index.less
+++ b/ui/library/less/index.less
@@ -1,3 +1,4 @@
 @import 'colors.less';
 @import 'styles.less';
 @import 'zindex.less';
+@import (less) 'react-pdf/dist/esm/Page/AnnotationLayer.css';

--- a/ui/library/src/components/PageWrapper.tsx
+++ b/ui/library/src/components/PageWrapper.tsx
@@ -17,6 +17,7 @@ export type PageProps = {
   loading?: string | React.ReactElement | RenderFunction;
   noData?: string | React.ReactElement | RenderFunction;
   pageIndex: number;
+  renderAnnotationLayer?: boolean;
 };
 
 export type Props = {
@@ -30,6 +31,7 @@ export const PageWrapper: React.FunctionComponent<Props> = ({
   loading,
   noData,
   pageIndex,
+  renderAnnotationLayer,
 }: Props) => {
   const { rotation, scale } = React.useContext(TransformContext);
   const { pageDimensions } = React.useContext(DocumentContext);
@@ -67,7 +69,7 @@ export const PageWrapper: React.FunctionComponent<Props> = ({
         scale={scale}
         onClick={onClick}
         rotate={rotation}
-        renderAnnotationLayer={false}
+        renderAnnotationLayer={renderAnnotationLayer || false}
       />
     </div>
   );


### PR DESCRIPTION
https://github.com/allenai/scholar/issues/31029

Added the User guide instruction for PageWrapper. This is mostly a copy of the [react-pdf user guide](https://github.com/wojtekmaj/react-pdf#page).
Allow renderAnnotationLayer prop to be set.
Also including the stylesheet to allow annotations in PDFs as per [this](https://github.com/wojtekmaj/react-pdf#support-for-annotations) doc.

TODO: References show on the page. Sadly the internal link refs are not working.  One guess is we might be missing the `ref` to the page.

Set `renderAnnotationLayer` and added logging to `onGetAnnotationsSuccess` callback
```
      <Page
        width={getWidth()}
        error={error}
        loading={loading}
        noData={noData}
        pageIndex={pageIndex}
        scale={scale}
        onClick={onClick}
        rotate={rotation}
        renderAnnotationLayer={true}
        onGetAnnotationsSuccess={
          (annotations) => console.log({annotations})
        }
        {...extraProps}>
            {children}
      </Page>
```

<img width="1135" alt="image" src="https://user-images.githubusercontent.com/7431587/163912202-5187dab4-635b-4070-b451-4964ca773a3b.png">
