### PR TITLE
Fix TOC click reorientation

### DIFF
--- a/ui/library/src/components/outline/Outline.tsx
+++ b/ui/library/src/components/outline/Outline.tsx
@@ -37,9 +37,9 @@ export const Outline: React.FunctionComponent = () => {
         Reference: https://github.com/mozilla/pdf.js/blob/d3e1d7090ac6f582d0c277e8768ac63bbbaa1134/web/base_viewer.js#L1152
       */
       // The second and the fifth items are left out intentionally for not being used in scrolling function.
-      const [ref, , leftPoints, bottomPoints] = destArray;
+      const [ref, , , bottomPoints] = destArray;
       pdfDocProxy.getPageIndex(new Ref(ref)).then(refInfo => {
-        scrollToPosition(parseInt(refInfo.toString()), leftPoints, bottomPoints, rotation);
+        scrollToPosition(parseInt(refInfo.toString()), 0, bottomPoints, rotation);
       });
     });
   };


### PR DESCRIPTION
Ticket: https://github.com/allenai/scholar/issues/31239

Root cause: the `leftPoint` was set to the location of titles originally, so for titles on the right column the paper will reorientate to the right (though I don't think it is a bug since the contents on the left are not in the same section with the contents on the right) 
Solution: set `leftPoint` to 0 so the paper scroll vertically only

After
https://user-images.githubusercontent.com/84034381/158449494-d14481ad-1c07-4a7b-8db4-0bff2a80a28d.mp4


