### PR TITLE
31368 Update components to receive additional props

### DIFF
--- a/ui/library/src/components/BoundingBox.tsx
+++ b/ui/library/src/components/BoundingBox.tsx
@@ -22,6 +22,7 @@ export const BoundingBox: React.FunctionComponent<Props> = ({
   id,
   isHighlighted,
   onClick,
+  ...extraProps
 }: Props) => {
   const { pageDimensions } = React.useContext(DocumentContext);
   const { rotation, scale } = React.useContext(TransformContext);
@@ -37,6 +38,12 @@ export const BoundingBox: React.FunctionComponent<Props> = ({
   }, [pageDimensions, rotation, scale]);
 
   return (
-    <div id={id} className={componentClassName} style={getBoundingBoxStyle()} onClick={onClick} />
+    <div
+      id={id}
+      className={componentClassName}
+      style={getBoundingBoxStyle()}
+      onClick={onClick}
+      {...extraProps}
+    />
   );
 };

--- a/ui/library/src/components/DocumentWrapper.tsx
+++ b/ui/library/src/components/DocumentWrapper.tsx
@@ -12,7 +12,7 @@ export type Props = {
   children?: React.ReactNode;
 } & DocumentProps;
 
-export const DocumentWrapper: React.FunctionComponent<Props> = ({ children, ...rest }: Props) => {
+export const DocumentWrapper: React.FunctionComponent<Props> = ({ children, ...extraProps }: Props) => {
   initPdfWorker();
 
   const { pdfDocProxy, setNumPages, setPageDimensions, setPdfDocProxy } =
@@ -53,7 +53,7 @@ export const DocumentWrapper: React.FunctionComponent<Props> = ({ children, ...r
       options={{ cMapUrl: 'cmaps/', cMapPacked: true }}
       onLoadError={onPdfLoadError}
       onLoadSuccess={onPdfLoadSuccess}
-      {...rest}>
+      {...extraProps}>
       {children}
     </Document>
   );

--- a/ui/library/src/components/DocumentWrapper.tsx
+++ b/ui/library/src/components/DocumentWrapper.tsx
@@ -12,7 +12,10 @@ export type Props = {
   children?: React.ReactNode;
 } & DocumentProps;
 
-export const DocumentWrapper: React.FunctionComponent<Props> = ({ children, ...extraProps }: Props) => {
+export const DocumentWrapper: React.FunctionComponent<Props> = ({
+  children,
+  ...extraProps
+}: Props) => {
   initPdfWorker();
 
   const { pdfDocProxy, setNumPages, setPageDimensions, setPdfDocProxy } =

--- a/ui/library/src/components/DownloadButton.tsx
+++ b/ui/library/src/components/DownloadButton.tsx
@@ -8,7 +8,10 @@ export type Props = {
  * HTML anchor tag allows you to download a file from the same origin.
  * This is a workaround to download a file served from a different origin
  */
-export const DownloadButton: React.FunctionComponent<Props> = ({ pdfUrl, ...extraProps }: Props) => {
+export const DownloadButton: React.FunctionComponent<Props> = ({
+  pdfUrl,
+  ...extraProps
+}: Props) => {
   const [fetching, setFetching] = React.useState(false);
 
   const download = () => {
@@ -28,7 +31,12 @@ export const DownloadButton: React.FunctionComponent<Props> = ({ pdfUrl, ...extr
   };
 
   return (
-    <button disabled={fetching} onClick={() => download()} aria-label="Download PDF" {...extraProps}>
+    <button
+      disabled={fetching}
+      onClick={() => download()}
+      aria-label="Download PDF"
+      className="reader__download-btn"
+      {...extraProps}>
       Download
     </button>
   );

--- a/ui/library/src/components/DownloadButton.tsx
+++ b/ui/library/src/components/DownloadButton.tsx
@@ -8,7 +8,7 @@ export type Props = {
  * HTML anchor tag allows you to download a file from the same origin.
  * This is a workaround to download a file served from a different origin
  */
-export const DownloadButton: React.FunctionComponent<Props> = ({ pdfUrl }: Props) => {
+export const DownloadButton: React.FunctionComponent<Props> = ({ pdfUrl, ...extraProps }: Props) => {
   const [fetching, setFetching] = React.useState(false);
 
   const download = () => {
@@ -28,7 +28,7 @@ export const DownloadButton: React.FunctionComponent<Props> = ({ pdfUrl }: Props
   };
 
   return (
-    <button disabled={fetching} onClick={() => download()} aria-label="Download PDF">
+    <button disabled={fetching} onClick={() => download()} aria-label="Download PDF" {...extraProps}>
       Download
     </button>
   );

--- a/ui/library/src/components/HighlightOverlay.tsx
+++ b/ui/library/src/components/HighlightOverlay.tsx
@@ -13,6 +13,7 @@ export type Props = {
 export const HighlightOverlay: React.FunctionComponent<Props> = ({
   children,
   pageIndex,
+  ...extraProps
 }: Props) => {
   const { pageDimensions } = React.useContext(DocumentContext);
   const { rotation, scale } = React.useContext(TransformContext);
@@ -40,7 +41,7 @@ export const HighlightOverlay: React.FunctionComponent<Props> = ({
   );
 
   return (
-    <div className="reader__page-highlight-overlay" style={getPageStyle()}>
+    <div className="reader__page-highlight-overlay" style={getPageStyle()} {...extraProps}>
       <svg className="page-mask" style={getPageStyle()}>
         <mask id={maskId}>
           <rect style={getPageStyle()} fill="white"></rect>

--- a/ui/library/src/components/Overlay.tsx
+++ b/ui/library/src/components/Overlay.tsx
@@ -9,7 +9,7 @@ export type Props = {
   children?: React.ReactElement<typeof BoundingBox> | Array<React.ReactElement<typeof BoundingBox>>;
 };
 
-export const Overlay: React.FunctionComponent<Props> = ({ children }: Props) => {
+export const Overlay: React.FunctionComponent<Props> = ({ children, ...extraProps }: Props) => {
   const { pageDimensions } = React.useContext(DocumentContext);
   const { rotation, scale } = React.useContext(TransformContext);
 
@@ -18,7 +18,7 @@ export const Overlay: React.FunctionComponent<Props> = ({ children }: Props) => 
   }, [pageDimensions, rotation, scale]);
 
   return (
-    <div className="reader__page-overlay" style={getOverlayStyle()}>
+    <div className="reader__page-overlay" style={getOverlayStyle()} {...extraProps}>
       {children}
     </div>
   );

--- a/ui/library/src/components/PageWrapper.tsx
+++ b/ui/library/src/components/PageWrapper.tsx
@@ -57,7 +57,11 @@ export const PageWrapper: React.FunctionComponent<Props> = ({
   // and mis-aligning the text layer.
   // TODO: Can we CSS this to auto-shrink?
   return (
-    <div id={generatePageIdFromIndex(pageIndex)} className="reader__page" style={getPageStyle()} {...extraProps}>
+    <div
+      id={generatePageIdFromIndex(pageIndex)}
+      className="reader__page"
+      style={getPageStyle()}
+      {...extraProps}>
       {children}
       <Page
         width={getWidth()}

--- a/ui/library/src/components/PageWrapper.tsx
+++ b/ui/library/src/components/PageWrapper.tsx
@@ -30,6 +30,7 @@ export const PageWrapper: React.FunctionComponent<Props> = ({
   loading,
   noData,
   pageIndex,
+  ...extraProps
 }: Props) => {
   const { rotation, scale } = React.useContext(TransformContext);
   const { pageDimensions } = React.useContext(DocumentContext);
@@ -56,7 +57,7 @@ export const PageWrapper: React.FunctionComponent<Props> = ({
   // and mis-aligning the text layer.
   // TODO: Can we CSS this to auto-shrink?
   return (
-    <div id={generatePageIdFromIndex(pageIndex)} className="reader__page" style={getPageStyle()}>
+    <div id={generatePageIdFromIndex(pageIndex)} className="reader__page" style={getPageStyle()} {...extraProps}>
       {children}
       <Page
         width={getWidth()}

--- a/ui/library/src/components/ZoomInButton.tsx
+++ b/ui/library/src/components/ZoomInButton.tsx
@@ -6,7 +6,7 @@ export type Props = {
   children?: React.ReactNode;
 };
 
-export const ZoomInButton: React.FunctionComponent<Props> = ({ children }: Props) => {
+export const ZoomInButton: React.FunctionComponent<Props> = ({ children, ...extraProps }: Props) => {
   const { scale, setScale, zoomMultiplier } = React.useContext(TransformContext);
 
   const handleZoomIn = React.useCallback(
@@ -19,7 +19,7 @@ export const ZoomInButton: React.FunctionComponent<Props> = ({ children }: Props
   );
 
   return (
-    <button className="reader__zoom-btn zoom-in" onClick={handleZoomIn}>
+    <button className="reader__zoom-btn zoom-in" onClick={handleZoomIn} {...extraProps}>
       {children ? children : '+'}
     </button>
   );

--- a/ui/library/src/components/ZoomInButton.tsx
+++ b/ui/library/src/components/ZoomInButton.tsx
@@ -6,7 +6,10 @@ export type Props = {
   children?: React.ReactNode;
 };
 
-export const ZoomInButton: React.FunctionComponent<Props> = ({ children, ...extraProps }: Props) => {
+export const ZoomInButton: React.FunctionComponent<Props> = ({
+  children,
+  ...extraProps
+}: Props) => {
   const { scale, setScale, zoomMultiplier } = React.useContext(TransformContext);
 
   const handleZoomIn = React.useCallback(

--- a/ui/library/src/components/ZoomOutButton.tsx
+++ b/ui/library/src/components/ZoomOutButton.tsx
@@ -6,7 +6,7 @@ export type Props = {
   children?: React.ReactNode;
 };
 
-export const ZoomOutButton: React.FunctionComponent = ({ children }: Props) => {
+export const ZoomOutButton: React.FunctionComponent = ({ children, ...extraProps }: Props) => {
   const { scale, setScale, zoomMultiplier } = React.useContext(TransformContext);
 
   const handleZoomOut = React.useCallback(
@@ -19,7 +19,7 @@ export const ZoomOutButton: React.FunctionComponent = ({ children }: Props) => {
   );
 
   return (
-    <button className="reader__zoom-btn zoom-out" onClick={handleZoomOut}>
+    <button className="reader__zoom-btn zoom-out" onClick={handleZoomOut} {...extraProps}>
       {children ? children : '-'}
     </button>
   );

--- a/ui/library/src/components/outline/Outline.tsx
+++ b/ui/library/src/components/outline/Outline.tsx
@@ -7,7 +7,7 @@ import { NodeDestination, OutlineNode } from '../types/outline';
 import { OutlineItem } from './OutlineItem';
 import Ref from './Ref';
 
-export const Outline: React.FunctionComponent = () => {
+export const Outline: React.FunctionComponent = ({ ...extraProps }) => {
   const { outline, pdfDocProxy, setOutline } = React.useContext(DocumentContext);
   const { rotation } = React.useContext(TransformContext);
 
@@ -44,5 +44,7 @@ export const Outline: React.FunctionComponent = () => {
     });
   };
 
-  return <div>{!!outline && <OutlineItem items={outline} onClick={clickHandler} />}</div>;
+  return <div {...extraProps}>
+    {!!outline && <OutlineItem items={outline} onClick={clickHandler} />}
+  </div>;
 };

--- a/ui/library/src/components/outline/Outline.tsx
+++ b/ui/library/src/components/outline/Outline.tsx
@@ -44,7 +44,9 @@ export const Outline: React.FunctionComponent = ({ ...extraProps }) => {
     });
   };
 
-  return <div {...extraProps}>
-    {!!outline && <OutlineItem items={outline} onClick={clickHandler} />}
-  </div>;
+  return (
+    <div className="reader__outline" {...extraProps}>
+      {!!outline && <OutlineItem items={outline} onClick={clickHandler} />}
+    </div>
+  );
 };

--- a/ui/library/src/components/outline/OutlineItem.tsx
+++ b/ui/library/src/components/outline/OutlineItem.tsx
@@ -22,7 +22,7 @@ export const OutlineItem: React.FunctionComponent<Props> = ({ items, onClick }: 
 
     // If an item has sub titles, render <OutlineItem />
     return (
-      <li key={item.title}>
+      <li key={item.title} className="reader__outline-item">
         <a href="#" onClick={clickHandler}>
           {item.title}
         </a>
@@ -31,5 +31,5 @@ export const OutlineItem: React.FunctionComponent<Props> = ({ items, onClick }: 
     );
   }
 
-  return <ul>{items.map(item => renderItem(item))}</ul>;
+  return <ul className="reader__outline-items">{items.map(item => renderItem(item))}</ul>;
 };


### PR DESCRIPTION
## Description

Ticket: https://github.com/allenai/scholar/issues/31368
Subtask of: https://github.com/allenai/scholar/issues/31012

We need to add Heap IDs to the Reader components on the S2 side of things, so I modified the PDF CL components to accept optional additional props.

Changes in this ticket:
- Update the following components to receive additional props: `BoundingBox`, `ZoomInButton`, `ZoomOutButton`, `PageWrapper`, `HighlightOverlay`, `Overlay`, `DownloadButton`, `Outline`
- Update existing `DocumentWrapper` variable name for additional props to match what was added for the other components
- Put classNames on the `DownloadButton`, `Outline`, and `OutlineItem` components to make targeting these components from external sources easier

## Reviewer Instructions

N/A

## Testing Plan
- Verified demo reader loads successfully and existing functionality still works as expected: zoom buttons, rotate buttons, outline w/ click target, highlight overlay, overlay, highlight text, download button.
- Spot checked various components by adding bogus props to them in the demo app and confirming the props show up in the DOM. Removed these bogus props before submitting this PR though.