### PR TITLE
Enable default redirection behavior for hyperlinks

### DIFF
--- a/ui/library/index.ts
+++ b/ui/library/index.ts
@@ -3,7 +3,7 @@
  */
 
 import './less/index.less';
-
+import 'react-pdf/dist/esm/Page/AnnotationLayer.css';
 import { BoundingBox, Props as BoundingBoxProps } from './src/components/BoundingBox';
 import { DocumentWrapper, Props as DocumentWrapperProps } from './src/components/DocumentWrapper';
 import { DownloadButton, Props as DownloadButtonProps } from './src/components/DownloadButton';

--- a/ui/library/index.ts
+++ b/ui/library/index.ts
@@ -3,7 +3,7 @@
  */
 
 import './less/index.less';
-import 'react-pdf/dist/esm/Page/AnnotationLayer.css';
+
 import { BoundingBox, Props as BoundingBoxProps } from './src/components/BoundingBox';
 import { DocumentWrapper, Props as DocumentWrapperProps } from './src/components/DocumentWrapper';
 import { DownloadButton, Props as DownloadButtonProps } from './src/components/DownloadButton';

--- a/ui/library/less/index.less
+++ b/ui/library/less/index.less
@@ -1,3 +1,5 @@
+@import (less) 'react-pdf/dist/esm/Page/AnnotationLayer.css';
 @import 'colors.less';
+@import 'links.less';
 @import 'styles.less';
 @import 'zindex.less';

--- a/ui/library/less/links.less
+++ b/ui/library/less/links.less
@@ -1,0 +1,11 @@
+// This rule overwrites default react-pdf styles for links
+.annotationLayer {
+  & section {
+    border: none!important;
+  }
+
+  & .linkAnnotation > a:hover {
+    background: none;
+    box-shadow: none;
+  }
+}

--- a/ui/library/package.json
+++ b/ui/library/package.json
@@ -46,7 +46,7 @@
     "mini-css-extract-plugin": "2.4.3",
     "mocha": "8.4.0",
     "prettier": "2.3.2",
-    "react-pdf": "5.3.2",
+    "react-pdf": "5.7.2",
     "remove-files-webpack-plugin": "1.4.5",
     "sinon": "11.1.1",
     "style-loader": "3.1.0",

--- a/ui/library/src/components/DocumentWrapper.tsx
+++ b/ui/library/src/components/DocumentWrapper.tsx
@@ -59,7 +59,7 @@ export const DocumentWrapper: React.FunctionComponent<Props> = ({
     if (!pdfDocProxy) {
       return;
     }
-    
+
     // Scroll to the destination of the item
     pdfDocProxy.getDestination(param.dest).then(destArray => {
       if (!destArray) {
@@ -78,6 +78,7 @@ export const DocumentWrapper: React.FunctionComponent<Props> = ({
       options={{ cMapUrl: 'cmaps/', cMapPacked: true }}
       onLoadError={onPdfLoadError}
       onLoadSuccess={onPdfLoadSuccess}
+      externalLinkTarget="_blank"
       // @ts-ignore: the arguments should be { dest, pageIndex, pageNumber }
       // @types/react-pdf hasn't updated the function signature
       // https://github.com/DefinitelyTyped/DefinitelyTyped/blob/d73eb652e0ba8f89395a0ef2ba69cf1e640ce5be/types/react-pdf/dist/Document.d.ts#L72

--- a/ui/library/src/components/DocumentWrapper.tsx
+++ b/ui/library/src/components/DocumentWrapper.tsx
@@ -9,7 +9,7 @@ import { getErrorMessage } from '../utils/errorMessage';
 import { initPdfWorker } from '../utils/pdfWorker';
 import { computePageDimensions, IPDFPageProxy } from '../utils/scale';
 import { scrollToPosition } from '../utils/scroll';
-import Ref from './outline/Ref';
+import { Destination, Ref } from './types/destination';
 
 export type Props = {
   children?: React.ReactNode;
@@ -55,7 +55,7 @@ export const DocumentWrapper: React.FunctionComponent<Props> = ({
     setIsLoading(false);
   }, []);
 
-  const onItemClicked = (param: any): void => {
+  const onItemClicked = (param: Destination): void => {
     if (!pdfDocProxy) {
       return;
     }

--- a/ui/library/src/components/DocumentWrapper.tsx
+++ b/ui/library/src/components/DocumentWrapper.tsx
@@ -7,6 +7,8 @@ import { UiContext } from '../context/UiContext';
 import { getErrorMessage } from '../utils/errorMessage';
 import { initPdfWorker } from '../utils/pdfWorker';
 import { computePageDimensions, IPDFPageProxy } from '../utils/scale';
+import { scrollToPosition } from '../utils/scroll';
+import Ref from './outline/Ref';
 
 export type Props = {
   children?: React.ReactNode;
@@ -51,11 +53,32 @@ export const DocumentWrapper: React.FunctionComponent<Props> = ({
     setIsLoading(false);
   }, []);
 
+  const onItemClicked = (param: any): void => {
+    if (!pdfDocProxy) {
+      return;
+    }
+
+    // Scroll to the destination of the item
+    pdfDocProxy.getDestination(param.dest).then(destArray => {
+      if (!destArray) {
+        return;
+      }
+
+      const [ref, , , bottomPoints] = destArray;
+      pdfDocProxy.getPageIndex(new Ref(ref)).then(refInfo => {
+        console.log(refInfo);
+        scrollToPosition(parseInt(refInfo.toString()), 0, bottomPoints);
+      });
+    });
+  };
+
   return (
     <Document
       options={{ cMapUrl: 'cmaps/', cMapPacked: true }}
       onLoadError={onPdfLoadError}
       onLoadSuccess={onPdfLoadSuccess}
+      // @ts-ignore: an object with { dest, pageIndex, pageNumber } is passed to the handler function but tslint thinks it should be { pageNumber }
+      onItemClick={onItemClicked}
       {...extraProps}>
       {children}
     </Document>

--- a/ui/library/src/components/DocumentWrapper.tsx
+++ b/ui/library/src/components/DocumentWrapper.tsx
@@ -1,4 +1,4 @@
-import { PDFDocumentProxy } from 'pdfjs-dist/types/display/api';
+import { PDFDocumentProxy } from 'pdfjs-dist';
 import * as React from 'react';
 import { Document, DocumentProps } from 'react-pdf';
 

--- a/ui/library/src/components/DocumentWrapper.tsx
+++ b/ui/library/src/components/DocumentWrapper.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { Document, DocumentProps } from 'react-pdf';
 
 import { DocumentContext } from '../context/DocumentContext';
+import { TransformContext } from '../context/TransformContext';
 import { UiContext } from '../context/UiContext';
 import { getErrorMessage } from '../utils/errorMessage';
 import { initPdfWorker } from '../utils/pdfWorker';
@@ -22,6 +23,7 @@ export const DocumentWrapper: React.FunctionComponent<Props> = ({
 
   const { pdfDocProxy, setNumPages, setPageDimensions, setPdfDocProxy } =
     React.useContext(DocumentContext);
+  const { rotation } = React.useContext(TransformContext);
   const { setErrorMessage, setIsLoading } = React.useContext(UiContext);
 
   function getFirstPage(pdfDoc: PDFDocumentProxy): Promise<IPDFPageProxy> {
@@ -66,8 +68,7 @@ export const DocumentWrapper: React.FunctionComponent<Props> = ({
 
       const [ref, , , bottomPoints] = destArray;
       pdfDocProxy.getPageIndex(new Ref(ref)).then(refInfo => {
-        console.log(refInfo);
-        scrollToPosition(parseInt(refInfo.toString()), 0, bottomPoints);
+        scrollToPosition(parseInt(refInfo.toString()), 0, bottomPoints, rotation);
       });
     });
   };

--- a/ui/library/src/components/DocumentWrapper.tsx
+++ b/ui/library/src/components/DocumentWrapper.tsx
@@ -59,7 +59,7 @@ export const DocumentWrapper: React.FunctionComponent<Props> = ({
     if (!pdfDocProxy) {
       return;
     }
-
+    
     // Scroll to the destination of the item
     pdfDocProxy.getDestination(param.dest).then(destArray => {
       if (!destArray) {
@@ -78,7 +78,9 @@ export const DocumentWrapper: React.FunctionComponent<Props> = ({
       options={{ cMapUrl: 'cmaps/', cMapPacked: true }}
       onLoadError={onPdfLoadError}
       onLoadSuccess={onPdfLoadSuccess}
-      // @ts-ignore: an object with { dest, pageIndex, pageNumber } is passed to the handler function but tslint thinks it should be { pageNumber }
+      // @ts-ignore: the arguments should be { dest, pageIndex, pageNumber }
+      // @types/react-pdf hasn't updated the function signature
+      // https://github.com/DefinitelyTyped/DefinitelyTyped/blob/d73eb652e0ba8f89395a0ef2ba69cf1e640ce5be/types/react-pdf/dist/Document.d.ts#L72
       onItemClick={onItemClicked}
       {...extraProps}>
       {children}

--- a/ui/library/src/components/PageWrapper.tsx
+++ b/ui/library/src/components/PageWrapper.tsx
@@ -41,10 +41,6 @@ export const PageWrapper: React.FunctionComponent<Props> = ({
     return null;
   }
 
-  const onClick = React.useCallback((e: unknown) => {
-    console.log(e);
-  }, []);
-
   const getWidth = React.useCallback(() => {
     return getPageWidth(pageDimensions, rotation);
   }, [pageDimensions, rotation]);
@@ -70,9 +66,8 @@ export const PageWrapper: React.FunctionComponent<Props> = ({
         noData={noData}
         pageIndex={pageIndex}
         scale={scale}
-        onClick={onClick}
         rotate={rotation}
-        renderAnnotationLayer={false}
+        renderAnnotationLayer={true}
       />
     </div>
   );

--- a/ui/library/src/components/outline/Outline.tsx
+++ b/ui/library/src/components/outline/Outline.tsx
@@ -3,9 +3,9 @@ import * as React from 'react';
 import { DocumentContext } from '../../context/DocumentContext';
 import { TransformContext } from '../../context/TransformContext';
 import { scrollToPosition } from '../../utils/scroll';
+import { Ref } from '../types/destination';
 import { NodeDestination, OutlineNode } from '../types/outline';
 import { OutlineItem } from './OutlineItem';
-import Ref from './Ref';
 
 export const Outline: React.FunctionComponent = ({ ...extraProps }) => {
   const { outline, pdfDocProxy, setOutline } = React.useContext(DocumentContext);

--- a/ui/library/src/components/outline/Outline.tsx
+++ b/ui/library/src/components/outline/Outline.tsx
@@ -26,6 +26,8 @@ export const Outline: React.FunctionComponent = ({ ...extraProps }) => {
       return;
     }
     pdfDocProxy.getDestination(dest.toString()).then(destArray => {
+      if (!destArray)
+        return
       /*
         destArray returned by getDestination contains 5 items:
         1. Reference to the page where dest locates at

--- a/ui/library/src/components/outline/Outline.tsx
+++ b/ui/library/src/components/outline/Outline.tsx
@@ -26,8 +26,9 @@ export const Outline: React.FunctionComponent = ({ ...extraProps }) => {
       return;
     }
     pdfDocProxy.getDestination(dest.toString()).then(destArray => {
-      if (!destArray)
-        return
+      if (!destArray) {
+        return;
+      }
       /*
         destArray returned by getDestination contains 5 items:
         1. Reference to the page where dest locates at

--- a/ui/library/src/components/types/destination.ts
+++ b/ui/library/src/components/types/destination.ts
@@ -1,11 +1,17 @@
-import { PageReference } from '../types/page';
+import { PageReference } from './page';
+
+export type Destination = {
+  dest: string;
+  pageIndex: number;
+  pageNumber: number;
+};
 
 /**
  * This class is the definition of the first item when Destination is returned as an array.
  * It is created based on the same class in 'react-pdf' library:
  * https://github.com/wojtekmaj/react-pdf/blob/ca4453f123af51e2faed39a8a62800901030459a/src/Ref.js
  */
-export default class Ref implements PageReference {
+export class Ref implements PageReference {
   num: number;
   gen: number;
 

--- a/ui/library/src/context/ContextProvider.tsx
+++ b/ui/library/src/context/ContextProvider.tsx
@@ -1,4 +1,4 @@
-import { PDFDocumentProxy } from 'pdfjs-dist/types/display/api';
+import { PDFDocumentProxy } from 'pdfjs-dist';
 import * as React from 'react';
 
 import { Dimensions } from '../components/types/boundingBox';

--- a/ui/library/src/context/DocumentContext.ts
+++ b/ui/library/src/context/DocumentContext.ts
@@ -1,4 +1,4 @@
-import { PDFDocumentProxy } from 'pdfjs-dist/types/display/api';
+import { PDFDocumentProxy } from 'pdfjs-dist';
 import * as React from 'react';
 
 import { Dimensions } from '../components/types/boundingBox';

--- a/ui/library/test/utils/pdfWorker.test.ts
+++ b/ui/library/test/utils/pdfWorker.test.ts
@@ -7,7 +7,7 @@ describe('initPdfWorker', () => {
   it('pdf worker CDN matches the check in pingdom.com', () => {
     initPdfWorker();
     expect(pdfjs.GlobalWorkerOptions.workerSrc).to.equal(
-      '//cdnjs.cloudflare.com/ajax/libs/pdf.js/2.6.347/pdf.worker.min.js'
+      '//cdnjs.cloudflare.com/ajax/libs/pdf.js/2.12.313/pdf.worker.min.js'
     );
   });
 });

--- a/ui/library/yarn.lock
+++ b/ui/library/yarn.lock
@@ -2941,15 +2941,10 @@ pathval@^1.1.1:
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
   integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
 
-pdfjs-dist@*:
+pdfjs-dist@*, pdfjs-dist@2.12.313:
   version "2.12.313"
   resolved "https://registry.yarnpkg.com/pdfjs-dist/-/pdfjs-dist-2.12.313.tgz#62f2273737bb956267ae2e02cdfaddcb1099819c"
   integrity sha512-1x6iXO4Qnv6Eb+YFdN5JdUzt4pAkxSp3aLAYPX93eQCyg/m7QFzXVWJHJVtoW48CI8HCXju4dSkhQZwoheL5mA==
-
-pdfjs-dist@2.6.347:
-  version "2.6.347"
-  resolved "https://registry.yarnpkg.com/pdfjs-dist/-/pdfjs-dist-2.6.347.tgz#f257ed66e83be900cd0fd28524a2187fb9e25cd5"
-  integrity sha512-QC+h7hG2su9v/nU1wEI3SnpPIrqJODL7GTDFvR74ANKGq1AFJW16PH8VWnhpiTi9YcLSFV9xLeWSgq+ckHLdVQ==
 
 performance-now@^2.1.0:
   version "2.1.0"
@@ -3151,10 +3146,10 @@ react-is@^16.13.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-pdf@5.3.2:
-  version "5.3.2"
-  resolved "https://registry.yarnpkg.com/react-pdf/-/react-pdf-5.3.2.tgz#517109d2a32ea7450dea49f7e5cc8e10bd2cfc4b"
-  integrity sha512-gT2xeUAUJem5UWNZYIQSPJAlPDbc3mIIhEgGK8P/qo1B68WIE4R4v3tNFYM9e5nqlKnGZG4Cd68SetlmnPejwA==
+react-pdf@5.7.2:
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/react-pdf/-/react-pdf-5.7.2.tgz#c458dedf7983822668b40dcac1eae052c1f6e056"
+  integrity sha512-hdDwvf007V0i2rPCqQVS1fa70CXut17SN3laJYlRHzuqcu8sLLjEoeXihty6c0Ev5g1mw31b8OT8EwRw1s8C4g==
   dependencies:
     "@babel/runtime" "^7.0.0"
     file-loader "^6.0.0"
@@ -3162,8 +3157,10 @@ react-pdf@5.3.2:
     make-event-props "^1.1.0"
     merge-class-names "^1.1.1"
     merge-refs "^1.0.0"
-    pdfjs-dist "2.6.347"
+    pdfjs-dist "2.12.313"
     prop-types "^15.6.2"
+    tiny-invariant "^1.0.0"
+    tiny-warning "^1.0.0"
 
 react-shallow-renderer@^16.13.1:
   version "16.14.1"
@@ -3627,6 +3624,16 @@ text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
+
+tiny-invariant@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.2.0.tgz#a1141f86b672a9148c72e978a19a73b9b94a15a9"
+  integrity sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg==
+
+tiny-warning@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
+  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
 
 to-regex-range@^5.0.1:
   version "5.0.1"


### PR DESCRIPTION
## Description
https://github.com/allenai/scholar/issues/31029

## Reviewer Instructions
- The old version of `react-pdf` library has some issues around `linkService` that makes link redirection buggy. So I update the package to `v5.7.2`
- Enable annotation layers for each page
- Make PDF scrolls to the position of items when being clicked
- Overwrite the default `react-pdf` link styles. There will be no background colors and borders but only gesture when hovering on links.
- Users will be directs to new tabs when clicking on external links

## Testing Plan
Tested manually on S2 and also ran unit tests

## Screenshot
### Before

https://user-images.githubusercontent.com/84034381/164566860-e79f9cbe-d7f6-4102-bdab-9826bff7548a.mp4


### After

<img width="565" alt="image" src="https://user-images.githubusercontent.com/84034381/164567662-dd7f8c18-8681-4d22-8e8a-b12326c99844.png">


https://user-images.githubusercontent.com/84034381/164567265-61b917d7-43f3-4724-bead-d600f5650076.mp4


