### PR TITLE
Adjust z-index of bounding box

### DIFF
--- a/ui/library/less/zindex.less
+++ b/ui/library/less/zindex.less
@@ -1,1 +1,1 @@
-@z-index-bounding-box-overlay: 10;
+@z-index-bounding-box-overlay: 1;


### PR DESCRIPTION
## Description
https://github.com/allenai/scholar/issues/32066

Root cause: the z-index of bounding box is higher than the tooltip box of Hypothes.is
Solution: adjust the z-index to 1

### Before
![image](https://user-images.githubusercontent.com/84034381/167685748-95cbd63a-8269-4d02-9129-173f98aecca7.png)

### After
![May-10-2022 10-23-09](https://user-images.githubusercontent.com/84034381/167686726-fa69aad2-b19a-44e4-9459-c632dd43a540.gif)

When highlighted text is overlapped with bounding boxes
![May-10-2022 10-23-19](https://user-images.githubusercontent.com/84034381/167686740-3b2dbf65-cd22-4fe5-85c9-b19590d11a5d.gif)

