### PR TITLE
Remove margin top of the bounding box underline

### DIFF
--- a/ui/library/less/styles.less
+++ b/ui/library/less/styles.less
@@ -1,4 +1,3 @@
-@bounding-box-padding: 3px;
 @bounding-box-border: 2px dotted @initial-blue;
 
 .reader__page {
@@ -39,21 +38,17 @@
   
   &.rotate0 {
     border-bottom: @bounding-box-border;
-    margin-top: @bounding-box-padding;
   }
   &.rotate90 {
     border-left: @bounding-box-border;
-    margin-left: -1 * @bounding-box-padding;
   }
 
   &.rotate180 {
     border-top: @bounding-box-border;
-    margin-top: -1 * @bounding-box-padding;
   }
 
   &.rotate270 {
     border-right: @bounding-box-border;
-    margin-left: @bounding-box-padding;
   }
 }
 


### PR DESCRIPTION
https://github.com/allenai/scholar/issues/31916#issuecomment-1140047963
Avoid underline shifts too much.

### Before
<img width="805" alt="Screen Shot 2022-06-07 at 15 03 24" src="https://user-images.githubusercontent.com/84034381/172490629-f2af5a1e-aa2f-4503-9066-f0a2fa13e714.png">

### After
<img width="781" alt="Screen Shot 2022-06-07 at 15 04 01" src="https://user-images.githubusercontent.com/84034381/172490709-1c805398-88eb-4068-ad05-c299b15d4f1c.png">

