### PR TITLE
Fix Scroll Issue

### DIFF
--- a/ui/demo/less/reader.less
+++ b/ui/demo/less/reader.less
@@ -19,6 +19,7 @@ body {
 
 .reader__main {
   grid-area: main;
+  overflow: auto;
   position: relative;
 }
 
@@ -27,7 +28,6 @@ body {
   flex-direction: column;
   align-items: center;
   background-color: @grey;
-  overflow: scroll;
   height: 100%;
   position: relative;
 }

--- a/ui/library/src/utils/scroll.ts
+++ b/ui/library/src/utils/scroll.ts
@@ -4,7 +4,7 @@ import { PageRotation } from '../utils/rotate';
 // Each page div is ID'd according to page index
 // e.g. reader_pg_0, reader_pg_1, etc.
 export const PAGE_NAV_TARGET_ID_ROOT = 'reader_pg_';
-export const SCROLLABLE_TARGET_DIV_CLASSNAME = 'reader__page-list';
+export const SCROLLABLE_TARGET_DIV_CLASSNAME = 'react-pdf__Document reader__main';
 
 const PDF_HEIGHT_POINTS = 792;
 const PDF_WIDTH_POINTS = 612;

--- a/ui/library/src/utils/scroll.ts
+++ b/ui/library/src/utils/scroll.ts
@@ -4,7 +4,7 @@ import { PageRotation } from '../utils/rotate';
 // Each page div is ID'd according to page index
 // e.g. reader_pg_0, reader_pg_1, etc.
 export const PAGE_NAV_TARGET_ID_ROOT = 'reader_pg_';
-export const SCROLLABLE_TARGET_DIV_CLASSNAME = 'react-pdf__Document reader__main';
+export const SCROLLABLE_TARGET_DIV_CLASSNAME = 'react-pdf__Document';
 
 const PDF_HEIGHT_POINTS = 792;
 const PDF_WIDTH_POINTS = 612;


### PR DESCRIPTION
## Description

Ref: https://github.com/allenai/scholar/issues/32270

With the new reader layout now using the outer scroll instead of the inner one which will render our `scroll.ts` to be useless. Its originally was targeting `reader__page-list` but now the scroll is on `react-pdf__Document reader__main`

## Reviewer Instructions

A minor tweak by changing the target div class name and verify if we click on any of the TOC it will scroll to correct location.

## Testing Plan

Manually test by clicking all the option of TOC and expect them to be able to scroll to the correct position. Other than that lint and format.

## Output / Screenshots

https://user-images.githubusercontent.com/84343285/175615038-beb3b1be-9958-43d8-9c32-71cf501c53be.mov

### A11y

No A11y involvement in this 