### PR TITLE
Move useContextProps() to Context files

### DIFF
--- a/ui/library/src/context/ContextProvider.tsx
+++ b/ui/library/src/context/ContextProvider.tsx
@@ -1,71 +1,12 @@
 import * as React from 'react';
-import { pdfjs } from 'react-pdf';
 
-import { Dimensions } from '../components/types/boundingBox';
-import { OutlineNode } from '../components/types/outline';
-import { Nullable } from '../components/types/utils';
-import { PageRotation } from '../utils/rotate';
-import { DocumentContext, IDocumentContext } from './DocumentContext';
-import { ITransformContext, TransformContext } from './TransformContext';
-import { IUiContext, UiContext } from './UiContext';
+import { DocumentContext, useDocumentContextProps } from './DocumentContext';
+import { TransformContext, useTransformContextProps } from './TransformContext';
+import { UiContext, useUiContextProps } from './UiContext';
 
 export type Props = {
   children?: React.ReactElement | Array<React.ReactElement>;
 };
-
-function useDocumentContextProps(): IDocumentContext {
-  const [numPages, setNumPages] = React.useState<number>(0);
-  const [outline, setOutline] = React.useState<Nullable<Array<OutlineNode>>>(null);
-  const [pageDimensions, setPageDimensions] = React.useState<Dimensions>({ height: 0, width: 0 });
-  const [pdfDocProxy, setPdfDocProxy] = React.useState<pdfjs.PDFDocumentProxy>();
-
-  return {
-    numPages,
-    outline,
-    pageDimensions: pageDimensions,
-    pdfDocProxy,
-    setNumPages,
-    setOutline,
-    setPageDimensions: setPageDimensions,
-    setPdfDocProxy,
-  };
-}
-
-function useTransformContextProps(): ITransformContext {
-  const [rotation, setRotation] = React.useState<PageRotation>(PageRotation.Rotate0);
-  const [scale, setScale] = React.useState<number>(1.0);
-  const [zoomMultiplier, setZoomMultiplier] = React.useState<number>(1.2);
-
-  return {
-    rotation,
-    scale,
-    setRotation,
-    setScale,
-    setZoomMultiplier,
-    zoomMultiplier,
-  };
-}
-
-function useUiContextProps(): IUiContext {
-  const [errorMessage, setErrorMessage] = React.useState<Nullable<string>>(null);
-  const [isLoading, setIsLoading] = React.useState<boolean>(true);
-  const [isShowingHighlightOverlay, setIsShowingHighlightOverlay] = React.useState<boolean>(false);
-  const [isShowingOutline, setIsShowingOutline] = React.useState<boolean>(false);
-  const [isShowingTextHighlight, setIsShowingTextHighlight] = React.useState<boolean>(false);
-
-  return {
-    errorMessage,
-    isLoading,
-    isShowingHighlightOverlay,
-    isShowingOutline,
-    isShowingTextHighlight,
-    setErrorMessage,
-    setIsLoading,
-    setIsShowingHighlightOverlay,
-    setIsShowingOutline,
-    setIsShowingTextHighlight,
-  };
-}
 
 export const ContextProvider: React.FunctionComponent<Props> = ({ children }: Props) => {
   const documentProps = useDocumentContextProps();

--- a/ui/library/src/context/DocumentContext.ts
+++ b/ui/library/src/context/DocumentContext.ts
@@ -35,3 +35,21 @@ export const DocumentContext = React.createContext<IDocumentContext>({
     logProviderWarning(`setPdfDocProxy(${pdfDocProxy})`, 'DocumentContext');
   },
 });
+
+export function useDocumentContextProps(): IDocumentContext {
+  const [numPages, setNumPages] = React.useState<number>(0);
+  const [outline, setOutline] = React.useState<Nullable<Array<OutlineNode>>>(null);
+  const [pageDimensions, setPageDimensions] = React.useState<Dimensions>({ height: 0, width: 0 });
+  const [pdfDocProxy, setPdfDocProxy] = React.useState<pdfjs.PDFDocumentProxy>();
+
+  return {
+    numPages,
+    outline,
+    pageDimensions: pageDimensions,
+    pdfDocProxy,
+    setNumPages,
+    setOutline,
+    setPageDimensions: setPageDimensions,
+    setPdfDocProxy,
+  };
+}

--- a/ui/library/src/context/TransformContext.ts
+++ b/ui/library/src/context/TransformContext.ts
@@ -26,3 +26,18 @@ export const TransformContext = React.createContext<ITransformContext>({
     logProviderWarning(`setZoomMultiplier(${zoom})`, 'TransformContext');
   },
 });
+
+export function useTransformContextProps(): ITransformContext {
+  const [rotation, setRotation] = React.useState<PageRotation>(PageRotation.Rotate0);
+  const [scale, setScale] = React.useState<number>(1.0);
+  const [zoomMultiplier, setZoomMultiplier] = React.useState<number>(1.2);
+
+  return {
+    rotation,
+    scale,
+    setRotation,
+    setScale,
+    setZoomMultiplier,
+    zoomMultiplier,
+  };
+}

--- a/ui/library/src/context/UiContext.ts
+++ b/ui/library/src/context/UiContext.ts
@@ -38,3 +38,24 @@ export const UiContext = React.createContext<IUiContext>({
     logProviderWarning(`setIsShowingTextHighlight(${isShowingTextHighlight})`, 'UiContext');
   },
 });
+
+export function useUiContextProps(): IUiContext {
+  const [errorMessage, setErrorMessage] = React.useState<Nullable<string>>(null);
+  const [isLoading, setIsLoading] = React.useState<boolean>(true);
+  const [isShowingHighlightOverlay, setIsShowingHighlightOverlay] = React.useState<boolean>(false);
+  const [isShowingOutline, setIsShowingOutline] = React.useState<boolean>(false);
+  const [isShowingTextHighlight, setIsShowingTextHighlight] = React.useState<boolean>(false);
+
+  return {
+    errorMessage,
+    isLoading,
+    isShowingHighlightOverlay,
+    isShowingOutline,
+    isShowingTextHighlight,
+    setErrorMessage,
+    setIsLoading,
+    setIsShowingHighlightOverlay,
+    setIsShowingOutline,
+    setIsShowingTextHighlight,
+  };
+}

--- a/ui/library/test/context/ContextProvider.test.tsx
+++ b/ui/library/test/context/ContextProvider.test.tsx
@@ -1,314 +1,57 @@
 import { expect } from 'chai';
 import { mount, ReactWrapper } from 'enzyme';
 import * as React from 'react';
-import { pdfjs } from 'react-pdf';
 
-import { Dimensions } from '../../src/components/types/boundingBox';
-import { OutlineNode } from '../../src/components/types/outline';
 import { Nullable } from '../../src/components/types/utils';
 import { ContextProvider } from '../../src/context/ContextProvider';
 import { DocumentContext, IDocumentContext } from '../../src/context/DocumentContext';
 import { ITransformContext, TransformContext } from '../../src/context/TransformContext';
 import { IUiContext, UiContext } from '../../src/context/UiContext';
-import { PageRotation } from '../../src/utils/rotate';
 
 describe('<ContextProvider/>', () => {
   let wrapper: ReactWrapper;
+  let documentContextProps: Nullable<IDocumentContext> = null;
+  let transformContextProps: Nullable<ITransformContext> = null;
+  let uiContextProps: Nullable<IUiContext> = null;
 
-  function expectTextFromClassName(className: string, value: string | number | boolean | null) {
-    const actual = wrapper.find(`.${className}`).text();
-    const message = `Expected text for element with class .${className} to be ${value} instead of ${actual}`;
-    expect(actual).equals(`${value}`, message);
-  }
-
-  describe('<DocumentContext.Provider/>', () => {
-    let _setNumPages: (numPages: number) => void;
-    let _setOutline: (outline: Nullable<Array<OutlineNode>>) => void;
-    let _setPageDimensions: (pageDimensions: Dimensions) => void;
-    let _setPdfDocProxy: (pdfDocProxy: pdfjs.PDFDocumentProxy) => void;
-
-    before(() => {
-      wrapper = mount(
-        <ContextProvider>
-          <DocumentContext.Consumer>
-            {(args: IDocumentContext) => {
-              const {
-                numPages,
-                outline,
-                pageDimensions,
-                pdfDocProxy,
-                setNumPages,
-                setOutline,
-                setPageDimensions,
-                setPdfDocProxy,
-              } = args;
-              _setNumPages = setNumPages;
-              _setOutline = setOutline;
-              _setPageDimensions = setPageDimensions;
-              _setPdfDocProxy = setPdfDocProxy;
-              return (
-                <div>
-                  <div className="numPages">{numPages}</div>
-                  <div className="outline">{outline === null ? 'null' : outline.length}</div>
-                  <div className="pageHeight">{pageDimensions.height}</div>
-                  <div className="pageWidth">{pageDimensions.width}</div>
-                  <div className="pdfDocProxy">{pdfDocProxy ? 'true' : 'false'}</div>
-                </div>
-              );
-            }}
-          </DocumentContext.Consumer>
-        </ContextProvider>
-      );
-    });
-
-    after(() => {
-      wrapper.unmount();
-    });
-
-    it('provides a default numPages', () => {
-      expectTextFromClassName('numPages', 0);
-    });
-
-    it('provides a default outline', () => {
-      expectTextFromClassName('outline', 'null');
-    });
-
-    it('provides a default pageDimensions with height and width', () => {
-      expectTextFromClassName('pageHeight', 0);
-      expectTextFromClassName('pageWidth', 0);
-    });
-
-    it('provides a default pdfDocProxy', () => {
-      expectTextFromClassName('pdfDocProxy', 'false');
-    });
-
-    it('provides a function to set numPages', () => {
-      expectTextFromClassName('numPages', 0);
-
-      _setNumPages(15);
-
-      expectTextFromClassName('numPages', 15);
-    });
-
-    it('provides a function to set outline', () => {
-      const outlineNode = {
-        title: 'Title',
-        bold: true,
-        italic: false,
-        color: [],
-        dest: {},
-        url: null,
-        unsafeUrl: 'test.com',
-        newWindow: true,
-        count: 5,
-        items: null,
-      };
-
-      expectTextFromClassName('outline', 'null');
-
-      _setOutline([outlineNode]);
-
-      expectTextFromClassName('outline', 1);
-    });
-
-    it('provides a function to set pageDimensions', () => {
-      expectTextFromClassName('pageHeight', 0);
-      expectTextFromClassName('pageWidth', 0);
-
-      _setPageDimensions({ height: 10, width: 20 });
-
-      expectTextFromClassName('pageHeight', 10);
-      expectTextFromClassName('pageWidth', 20);
-    });
-
-    it('provides a function to setPdfDocProxy', () => {
-      expectTextFromClassName('pdfDocProxy', 'false');
-
-      _setPdfDocProxy({} as pdfjs.PDFDocumentProxy);
-
-      expectTextFromClassName('pdfDocProxy', 'true');
-    });
+  beforeEach(() => {
+    wrapper = mount(
+      <ContextProvider>
+        <DocumentContext.Consumer>
+          {(args: IDocumentContext) => {
+            documentContextProps = args;
+            return null;
+          }}
+        </DocumentContext.Consumer>
+        <TransformContext.Consumer>
+          {(args: ITransformContext) => {
+            transformContextProps = args;
+            return null;
+          }}
+        </TransformContext.Consumer>
+        <UiContext.Consumer>
+          {(args: IUiContext) => {
+            uiContextProps = args;
+            return null;
+          }}
+        </UiContext.Consumer>
+      </ContextProvider>
+    );
   });
 
-  describe('<TransformContext.Provider/>', () => {
-    let _setRotation: (rotation: PageRotation) => void;
-    let _setScale: (scale: number) => void;
-    let _setZoomMultiplier: (zoom: number) => void;
-
-    before(() => {
-      wrapper = mount(
-        <ContextProvider>
-          <TransformContext.Consumer>
-            {(args: ITransformContext) => {
-              const { rotation, scale, zoomMultiplier, setRotation, setScale, setZoomMultiplier } =
-                args;
-              _setRotation = setRotation;
-              _setScale = setScale;
-              _setZoomMultiplier = setZoomMultiplier;
-              return (
-                <div>
-                  <div className="scale">{scale}</div>
-                  <div className="rotation">{rotation}</div>
-                  <div className="zoom">{zoomMultiplier}</div>
-                </div>
-              );
-            }}
-          </TransformContext.Consumer>
-        </ContextProvider>
-      );
-    });
-
-    after(() => {
-      wrapper.unmount();
-    });
-
-    it('provides a default rotation', () => {
-      expectTextFromClassName('rotation', 0);
-    });
-
-    it('provides a default scale', () => {
-      expectTextFromClassName('scale', 1);
-    });
-
-    it('provides a default zoom multiplier', () => {
-      expectTextFromClassName('zoom', 1.2);
-    });
-
-    it('provides a function to set rotation', () => {
-      expectTextFromClassName('rotation', 0);
-
-      _setRotation(PageRotation.Rotate90);
-
-      expectTextFromClassName('rotation', 90);
-    });
-
-    it('provides a function to set scale', () => {
-      expectTextFromClassName('scale', 1);
-
-      _setScale(1.2);
-
-      expectTextFromClassName('scale', 1.2);
-    });
-
-    it('provides a function to set zoom multiplier', () => {
-      expectTextFromClassName('zoom', 1.2);
-
-      _setZoomMultiplier(2.5);
-
-      expectTextFromClassName('zoom', 2.5);
-    });
+  afterEach(() => {
+    wrapper.unmount();
   });
 
-  describe('<UIContext.Provider/>', () => {
-    let _setErrorMessage: (errorMessage: Nullable<string>) => void;
-    let _setIsShowingOutline: (isShowingOutline: boolean) => void;
-    let _setIsLoading: (isLoading: boolean) => void;
-    let _setIsShowingHighlightOverlay: (isShowingHighlightOverlay: boolean) => void;
-    let _setIsShowingTextHighlight: (isShowingTextHighlight: boolean) => void;
+  it('should create a DocumentContext', () => {
+    expect(documentContextProps).to.be.ok;
+  });
 
-    before(() => {
-      wrapper = mount(
-        <ContextProvider>
-          <UiContext.Consumer>
-            {(args: IUiContext) => {
-              const {
-                errorMessage,
-                isShowingOutline,
-                isLoading,
-                isShowingHighlightOverlay,
-                isShowingTextHighlight,
-                setErrorMessage,
-                setIsShowingOutline,
-                setIsLoading,
-                setIsShowingHighlightOverlay,
-                setIsShowingTextHighlight,
-              } = args;
-              _setErrorMessage = setErrorMessage;
-              _setIsShowingOutline = setIsShowingOutline;
-              _setIsLoading = setIsLoading;
-              _setIsShowingHighlightOverlay = setIsShowingHighlightOverlay;
-              _setIsShowingTextHighlight = setIsShowingTextHighlight;
-              return (
-                <div>
-                  <div className="errorMessage">
-                    {errorMessage === null ? 'null' : errorMessage}
-                  </div>
-                  <div className="isLoading">{isLoading.toString()}</div>
-                  <div className="isShowingHighlightOverlay">
-                    {isShowingHighlightOverlay.toString()}
-                  </div>
-                  <div className="isShowingOutline">{isShowingOutline.toString()}</div>
-                  <div className="isShowingTextHighlight">{isShowingTextHighlight.toString()}</div>
-                </div>
-              );
-            }}
-          </UiContext.Consumer>
-        </ContextProvider>
-      );
-    });
+  it('should create a TransformContext', () => {
+    expect(transformContextProps).to.be.ok;
+  });
 
-    after(() => {
-      wrapper.unmount();
-    });
-
-    it('provides a default errorMessage === null', () => {
-      expectTextFromClassName('errorMessage', null);
-    });
-
-    it('provides a default isShowingOutline', () => {
-      expectTextFromClassName('isShowingOutline', false);
-    });
-
-    it('provides a default isLoading', () => {
-      expectTextFromClassName('isLoading', true);
-    });
-
-    it('provides a default isShowingHighlightOverlay', () => {
-      expectTextFromClassName('isShowingHighlightOverlay', false);
-    });
-
-    it('provides a default isShowingTextHighlight', () => {
-      expectTextFromClassName('isShowingTextHighlight', false);
-    });
-
-    it('provides a function to set errorMessage', () => {
-      expectTextFromClassName('errorMessage', null);
-
-      _setErrorMessage('Test message');
-
-      expectTextFromClassName('errorMessage', 'Test message');
-    });
-
-    it('provides a function to set isShowingOutline', () => {
-      expectTextFromClassName('isShowingOutline', false);
-
-      _setIsShowingOutline(true);
-
-      expectTextFromClassName('isShowingOutline', true);
-    });
-
-    it('provides a function to set isLoading', () => {
-      expectTextFromClassName('isLoading', true);
-
-      _setIsLoading(false);
-
-      expectTextFromClassName('isLoading', false);
-    });
-
-    it('provides a function to set isShowingHighlightOverlay', () => {
-      expectTextFromClassName('isShowingHighlightOverlay', false);
-
-      _setIsShowingHighlightOverlay(true);
-
-      expectTextFromClassName('isShowingHighlightOverlay', true);
-    });
-
-    it('provides a function to set isShowingTextHighlight', () => {
-      expectTextFromClassName('isShowingTextHighlight', false);
-
-      _setIsShowingTextHighlight(true);
-
-      expectTextFromClassName('isShowingTextHighlight', true);
-    });
+  it('should create a UiContext', () => {
+    expect(uiContextProps).to.be.ok;
   });
 });

--- a/ui/library/test/context/DocumentContext.test.tsx
+++ b/ui/library/test/context/DocumentContext.test.tsx
@@ -1,0 +1,135 @@
+import { expect } from 'chai';
+import { mount, ReactWrapper } from 'enzyme';
+import * as React from 'react';
+import { pdfjs } from 'react-pdf';
+
+import { Dimensions } from '../../src/components/types/boundingBox';
+import { OutlineNode } from '../../src/components/types/outline';
+import { Nullable } from '../../src/components/types/utils';
+import {
+  DocumentContext,
+  IDocumentContext,
+  useDocumentContextProps,
+} from '../../src/context/DocumentContext';
+
+describe('<DocumentContext/>', () => {
+  let wrapper: ReactWrapper;
+
+  function expectTextFromClassName(className: string, value: string | number | boolean | null) {
+    const actual = wrapper.find(`.${className}`).text();
+    const message = `Expected text for element with class .${className} to be ${value} instead of ${actual}`;
+    expect(actual).equals(`${value}`, message);
+  }
+
+  function UseContext({ children }) {
+    const contextProps = useDocumentContextProps();
+    return <DocumentContext.Provider value={contextProps}>{children}</DocumentContext.Provider>;
+  }
+
+  let _setNumPages: (numPages: number) => void;
+  let _setOutline: (outline: Nullable<Array<OutlineNode>>) => void;
+  let _setPageDimensions: (pageDimensions: Dimensions) => void;
+  let _setPdfDocProxy: (pdfDocProxy: pdfjs.PDFDocumentProxy) => void;
+
+  beforeEach(() => {
+    wrapper = mount(
+      <UseContext>
+        <DocumentContext.Consumer>
+          {(args: IDocumentContext) => {
+            const {
+              numPages,
+              outline,
+              pageDimensions,
+              pdfDocProxy,
+              setNumPages,
+              setOutline,
+              setPageDimensions,
+              setPdfDocProxy,
+            } = args;
+            _setNumPages = setNumPages;
+            _setOutline = setOutline;
+            _setPageDimensions = setPageDimensions;
+            _setPdfDocProxy = setPdfDocProxy;
+            return (
+              <div>
+                <div className="numPages">{numPages}</div>
+                <div className="outline">{outline === null ? 'null' : outline.length}</div>
+                <div className="pageHeight">{pageDimensions.height}</div>
+                <div className="pageWidth">{pageDimensions.width}</div>
+                <div className="pdfDocProxy">{pdfDocProxy ? 'true' : 'false'}</div>
+              </div>
+            );
+          }}
+        </DocumentContext.Consumer>
+      </UseContext>
+    );
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  it('provides a default numPages', () => {
+    expectTextFromClassName('numPages', 0);
+  });
+
+  it('provides a default outline', () => {
+    expectTextFromClassName('outline', 'null');
+  });
+
+  it('provides a default pageDimensions with height and width', () => {
+    expectTextFromClassName('pageHeight', 0);
+    expectTextFromClassName('pageWidth', 0);
+  });
+
+  it('provides a default pdfDocProxy', () => {
+    expectTextFromClassName('pdfDocProxy', 'false');
+  });
+
+  it('provides a function to set numPages', () => {
+    expectTextFromClassName('numPages', 0);
+
+    _setNumPages(15);
+
+    expectTextFromClassName('numPages', 15);
+  });
+
+  it('provides a function to set outline', () => {
+    const outlineNode = {
+      title: 'Title',
+      bold: true,
+      italic: false,
+      color: [],
+      dest: {},
+      url: null,
+      unsafeUrl: 'test.com',
+      newWindow: true,
+      count: 5,
+      items: null,
+    };
+
+    expectTextFromClassName('outline', 'null');
+
+    _setOutline([outlineNode]);
+
+    expectTextFromClassName('outline', 1);
+  });
+
+  it('provides a function to set pageDimensions', () => {
+    expectTextFromClassName('pageHeight', 0);
+    expectTextFromClassName('pageWidth', 0);
+
+    _setPageDimensions({ height: 10, width: 20 });
+
+    expectTextFromClassName('pageHeight', 10);
+    expectTextFromClassName('pageWidth', 20);
+  });
+
+  it('provides a function to setPdfDocProxy', () => {
+    expectTextFromClassName('pdfDocProxy', 'false');
+
+    _setPdfDocProxy({} as pdfjs.PDFDocumentProxy);
+
+    expectTextFromClassName('pdfDocProxy', 'true');
+  });
+});

--- a/ui/library/test/context/DocumentContext.test.tsx
+++ b/ui/library/test/context/DocumentContext.test.tsx
@@ -21,7 +21,7 @@ describe('<DocumentContext/>', () => {
     expect(actual).equals(`${value}`, message);
   }
 
-  function UseContext({ children }) {
+  function UseContext({ children }: any) {
     const contextProps = useDocumentContextProps();
     return <DocumentContext.Provider value={contextProps}>{children}</DocumentContext.Provider>;
   }

--- a/ui/library/test/context/TransformContext.test.tsx
+++ b/ui/library/test/context/TransformContext.test.tsx
@@ -1,0 +1,92 @@
+import { expect } from 'chai';
+import { mount, ReactWrapper } from 'enzyme';
+import * as React from 'react';
+
+import {
+  ITransformContext,
+  TransformContext,
+  useTransformContextProps,
+} from '../../src/context/TransformContext';
+import { PageRotation } from '../../src/utils/rotate';
+
+describe('<TransformContext/>', () => {
+  let wrapper: ReactWrapper;
+
+  function expectTextFromClassName(className: string, value: string | number | boolean | null) {
+    const actual = wrapper.find(`.${className}`).text();
+    const message = `Expected text for element with class .${className} to be ${value} instead of ${actual}`;
+    expect(actual).equals(`${value}`, message);
+  }
+
+  function UseContext({ children }: any) {
+    const contextProps = useTransformContextProps();
+    return <TransformContext.Provider value={contextProps}>{children}</TransformContext.Provider>;
+  }
+
+  let _setRotation: (rotation: PageRotation) => void;
+  let _setScale: (scale: number) => void;
+  let _setZoomMultiplier: (zoom: number) => void;
+
+  beforeEach(() => {
+    wrapper = mount(
+      <UseContext>
+        <TransformContext.Consumer>
+          {(args: ITransformContext) => {
+            const { rotation, scale, zoomMultiplier, setRotation, setScale, setZoomMultiplier } =
+              args;
+            _setRotation = setRotation;
+            _setScale = setScale;
+            _setZoomMultiplier = setZoomMultiplier;
+            return (
+              <div>
+                <div className="scale">{scale}</div>
+                <div className="rotation">{rotation}</div>
+                <div className="zoom">{zoomMultiplier}</div>
+              </div>
+            );
+          }}
+        </TransformContext.Consumer>
+      </UseContext>
+    );
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  it('provides a default rotation', () => {
+    expectTextFromClassName('rotation', 0);
+  });
+
+  it('provides a default scale', () => {
+    expectTextFromClassName('scale', 1);
+  });
+
+  it('provides a default zoom multiplier', () => {
+    expectTextFromClassName('zoom', 1.2);
+  });
+
+  it('provides a function to set rotation', () => {
+    expectTextFromClassName('rotation', 0);
+
+    _setRotation(PageRotation.Rotate90);
+
+    expectTextFromClassName('rotation', 90);
+  });
+
+  it('provides a function to set scale', () => {
+    expectTextFromClassName('scale', 1);
+
+    _setScale(1.2);
+
+    expectTextFromClassName('scale', 1.2);
+  });
+
+  it('provides a function to set zoom multiplier', () => {
+    expectTextFromClassName('zoom', 1.2);
+
+    _setZoomMultiplier(2.5);
+
+    expectTextFromClassName('zoom', 2.5);
+  });
+});

--- a/ui/library/test/context/UiContext.test.tsx
+++ b/ui/library/test/context/UiContext.test.tsx
@@ -1,0 +1,130 @@
+import { expect } from 'chai';
+import { mount, ReactWrapper } from 'enzyme';
+import * as React from 'react';
+
+import { Nullable } from '../../src/components/types/utils';
+import { IUiContext, UiContext, useUiContextProps } from '../../src/context/UiContext';
+
+describe('<UiContext/>', () => {
+  let wrapper: ReactWrapper;
+
+  function expectTextFromClassName(className: string, value: string | number | boolean | null) {
+    const actual = wrapper.find(`.${className}`).text();
+    const message = `Expected text for element with class .${className} to be ${value} instead of ${actual}`;
+    expect(actual).equals(`${value}`, message);
+  }
+
+  function UseContext({ children }: any) {
+    const contextProps = useUiContextProps();
+    return <UiContext.Provider value={contextProps}>{children}</UiContext.Provider>;
+  }
+
+  let _setErrorMessage: (errorMessage: Nullable<string>) => void;
+  let _setIsShowingOutline: (isShowingOutline: boolean) => void;
+  let _setIsLoading: (isLoading: boolean) => void;
+  let _setIsShowingHighlightOverlay: (isShowingHighlightOverlay: boolean) => void;
+  let _setIsShowingTextHighlight: (isShowingTextHighlight: boolean) => void;
+
+  beforeEach(() => {
+    wrapper = mount(
+      <UseContext>
+        <UiContext.Consumer>
+          {(args: IUiContext) => {
+            const {
+              errorMessage,
+              isShowingOutline,
+              isLoading,
+              isShowingHighlightOverlay,
+              isShowingTextHighlight,
+              setErrorMessage,
+              setIsShowingOutline,
+              setIsLoading,
+              setIsShowingHighlightOverlay,
+              setIsShowingTextHighlight,
+            } = args;
+            _setErrorMessage = setErrorMessage;
+            _setIsShowingOutline = setIsShowingOutline;
+            _setIsLoading = setIsLoading;
+            _setIsShowingHighlightOverlay = setIsShowingHighlightOverlay;
+            _setIsShowingTextHighlight = setIsShowingTextHighlight;
+            return (
+              <div>
+                <div className="errorMessage">{errorMessage === null ? 'null' : errorMessage}</div>
+                <div className="isLoading">{isLoading.toString()}</div>
+                <div className="isShowingHighlightOverlay">
+                  {isShowingHighlightOverlay.toString()}
+                </div>
+                <div className="isShowingOutline">{isShowingOutline.toString()}</div>
+                <div className="isShowingTextHighlight">{isShowingTextHighlight.toString()}</div>
+              </div>
+            );
+          }}
+        </UiContext.Consumer>
+      </UseContext>
+    );
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  it('provides a default errorMessage === null', () => {
+    expectTextFromClassName('errorMessage', null);
+  });
+
+  it('provides a default isShowingOutline', () => {
+    expectTextFromClassName('isShowingOutline', false);
+  });
+
+  it('provides a default isLoading', () => {
+    expectTextFromClassName('isLoading', true);
+  });
+
+  it('provides a default isShowingHighlightOverlay', () => {
+    expectTextFromClassName('isShowingHighlightOverlay', false);
+  });
+
+  it('provides a default isShowingTextHighlight', () => {
+    expectTextFromClassName('isShowingTextHighlight', false);
+  });
+
+  it('provides a function to set errorMessage', () => {
+    expectTextFromClassName('errorMessage', null);
+
+    _setErrorMessage('Test message');
+
+    expectTextFromClassName('errorMessage', 'Test message');
+  });
+
+  it('provides a function to set isShowingOutline', () => {
+    expectTextFromClassName('isShowingOutline', false);
+
+    _setIsShowingOutline(true);
+
+    expectTextFromClassName('isShowingOutline', true);
+  });
+
+  it('provides a function to set isLoading', () => {
+    expectTextFromClassName('isLoading', true);
+
+    _setIsLoading(false);
+
+    expectTextFromClassName('isLoading', false);
+  });
+
+  it('provides a function to set isShowingHighlightOverlay', () => {
+    expectTextFromClassName('isShowingHighlightOverlay', false);
+
+    _setIsShowingHighlightOverlay(true);
+
+    expectTextFromClassName('isShowingHighlightOverlay', true);
+  });
+
+  it('provides a function to set isShowingTextHighlight', () => {
+    expectTextFromClassName('isShowingTextHighlight', false);
+
+    _setIsShowingTextHighlight(true);
+
+    expectTextFromClassName('isShowingTextHighlight', true);
+  });
+});


### PR DESCRIPTION
This PR moves the `use*ContextProps()` functions from `ContextProvider` into their own Context files. This way, the typing can be self contained within a single file, and it reduces the knowledge required for `ContextProvider`. 

The unit tests have also been refactored so each context is tested separately from the `ContextProvider` (which now only tests that it creates contexts, not what the contexts do).