### PR TITLE
Update react-pdf to use the new 6.0 beta version

### DIFF
--- a/ui/library/dist/index.d.ts
+++ b/ui/library/dist/index.d.ts
@@ -248,6 +248,7 @@ declare module '@allenai/pdf-components/src/context/DocumentContext' {
         setPdfDocProxy: (pdfDocProxy: pdfjs.PDFDocumentProxy) => void;
     }
     export const DocumentContext: React.Context<IDocumentContext>;
+    export function useDocumentContextProps(): IDocumentContext;
 }
 
 declare module '@allenai/pdf-components/src/context/TransformContext' {
@@ -262,6 +263,7 @@ declare module '@allenai/pdf-components/src/context/TransformContext' {
         setZoomMultiplier: (zoom: number) => void;
     }
     export const TransformContext: React.Context<ITransformContext>;
+    export function useTransformContextProps(): ITransformContext;
 }
 
 declare module '@allenai/pdf-components/src/context/UiContext' {
@@ -280,6 +282,7 @@ declare module '@allenai/pdf-components/src/context/UiContext' {
         setIsShowingTextHighlight: (isShowingTextHighlight: boolean) => void;
     }
     export const UiContext: React.Context<IUiContext>;
+    export function useUiContextProps(): IUiContext;
 }
 
 declare module '@allenai/pdf-components/src/utils/rotate' {

--- a/ui/library/package.json
+++ b/ui/library/package.json
@@ -47,7 +47,7 @@
     "mini-css-extract-plugin": "2.4.3",
     "mocha": "8.4.0",
     "prettier": "2.3.2",
-    "react-pdf": "5.7.2",
+    "react-pdf": "6.0.0-beta.2",
     "remove-files-webpack-plugin": "1.4.5",
     "sinon": "11.1.1",
     "style-loader": "3.1.0",
@@ -61,6 +61,6 @@
   "peerDependencies": {
     "react": "17.0.2",
     "react-dom": "17.0.2",
-    "react-pdf": "5.7.2"
+    "react-pdf": "6.0.0-beta.2"
   }
 }

--- a/ui/library/test/utils/pdfWorker.test.ts
+++ b/ui/library/test/utils/pdfWorker.test.ts
@@ -7,7 +7,7 @@ describe('initPdfWorker', () => {
   it('pdf worker CDN matches the check in pingdom.com', () => {
     initPdfWorker();
     expect(pdfjs.GlobalWorkerOptions.workerSrc).to.equal(
-      '//cdnjs.cloudflare.com/ajax/libs/pdf.js/2.12.313/pdf.worker.min.js'
+      '//cdnjs.cloudflare.com/ajax/libs/pdf.js/2.14.305/pdf.worker.min.js'
     );
   });
 });

--- a/ui/library/yarn.lock
+++ b/ui/library/yarn.lock
@@ -1190,6 +1190,11 @@ domhandler@^4.0.0, domhandler@^4.2.0, domhandler@^4.3.0:
   dependencies:
     domelementtype "^2.2.0"
 
+dommatrix@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/dommatrix/-/dommatrix-1.0.3.tgz#e7c18e8d6f3abdd1fef3dd4aa74c4d2e620a0525"
+  integrity sha512-l32Xp/TLgWb8ReqbVJAFIvXmY7go4nTxxlWiAFyhoQw9RKEOHBZNnyGvJWqDVSPmq3Y9HlM4npqF/T6VMOXhww==
+
 domutils@^2.5.2, domutils@^2.7.0, domutils@^2.8.0:
   version "2.8.0"
   resolved "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz"
@@ -2906,7 +2911,15 @@ pathval@^1.1.1:
   resolved "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz"
   integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
 
-pdfjs-dist@2.12.313, pdfjs-dist@^2.10.377:
+pdfjs-dist@2.14.305:
+  version "2.14.305"
+  resolved "https://registry.yarnpkg.com/pdfjs-dist/-/pdfjs-dist-2.14.305.tgz#ed2ecb439ff8af5446c90a310ebd30bc1a91df62"
+  integrity sha512-5f7i25J1dKIBczhgfxEgNxfYNIxXEdxqo6Qb4ehY7Ja+p6AI4uUmk/OcVGXfRGm2ys5iaJJhJUwBFwv6Jl/Qww==
+  dependencies:
+    dommatrix "^1.0.1"
+    web-streams-polyfill "^3.2.1"
+
+pdfjs-dist@^2.10.377:
   version "2.12.313"
   resolved "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.12.313.tgz"
   integrity sha512-1x6iXO4Qnv6Eb+YFdN5JdUzt4pAkxSp3aLAYPX93eQCyg/m7QFzXVWJHJVtoW48CI8HCXju4dSkhQZwoheL5mA==
@@ -3111,10 +3124,10 @@ react-is@^16.8.1:
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-pdf@5.7.2:
-  version "5.7.2"
-  resolved "https://registry.npmjs.org/react-pdf/-/react-pdf-5.7.2.tgz"
-  integrity sha512-hdDwvf007V0i2rPCqQVS1fa70CXut17SN3laJYlRHzuqcu8sLLjEoeXihty6c0Ev5g1mw31b8OT8EwRw1s8C4g==
+react-pdf@6.0.0-beta.2:
+  version "6.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/react-pdf/-/react-pdf-6.0.0-beta.2.tgz#addb7a151d5cf2008e6013f3da64c966c3f5c5a2"
+  integrity sha512-WU8dnTYfUecJfetdahGMd5x3SEwxkHonDToOhCbrELHLh1N6pXaEHY6JjZal8tVHTtRZmMoOyglp8iIjHy2HjQ==
   dependencies:
     "@babel/runtime" "^7.0.0"
     file-loader "^6.0.0"
@@ -3122,7 +3135,7 @@ react-pdf@5.7.2:
     make-event-props "^1.1.0"
     merge-class-names "^1.1.1"
     merge-refs "^1.0.0"
-    pdfjs-dist "2.12.313"
+    pdfjs-dist "2.14.305"
     prop-types "^15.6.2"
     tiny-invariant "^1.0.0"
     tiny-warning "^1.0.0"
@@ -3785,6 +3798,11 @@ watchpack@^2.2.0:
   dependencies:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
+
+web-streams-polyfill@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz#71c2718c52b45fd49dbeee88634b3a60ceab42a6"
+  integrity sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==
 
 webidl-conversions@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
## Description

Ref: https://github.com/allenai/scholar/issues/32746
https://github.com/allenai/scholar/issues/32918

In order to make single canvas rendering works we still also need 6.0 version of `react-pdf`. Currently the official version is not yet published, they still just in beta. 

## Reviewer Instructions

Pull out the latest version into our repo. Performance mostly for other browser like Edge, Chrome, Firefox is normal. When it comes to Safari it does better than the old lagging state that we used to have as expected as last time i pull the repo, its not lagging any more but pages of pdf seem took longer than expected for rendering.

## Testing Plan

Manually testing if the site works from both S2, Pdf component

## Output / Screenshots

**Pdf Component**
Chrome
https://user-images.githubusercontent.com/84343285/178374854-7a6498c4-ce9d-4318-b708-567197510a1a.mov

Firefox

https://user-images.githubusercontent.com/84343285/178375171-2c1c44ff-0c07-4b2e-8715-d86c9ddd57fc.mov

Edge

https://user-images.githubusercontent.com/84343285/178375272-e9566d65-0683-4315-b221-1443cfca752e.mov

Safari

https://user-images.githubusercontent.com/84343285/178375376-c92efee9-2565-47e8-ab64-49c55493cb28.mov

**Scholar**
Chrome

https://user-images.githubusercontent.com/84343285/178375459-14f85fae-2582-4ced-895b-0abcdb06943f.mov

Firefox

https://user-images.githubusercontent.com/84343285/178375566-476a6c8c-0586-496f-afd6-3d8488568d28.mov
 
Edge


https://user-images.githubusercontent.com/84343285/178375645-ab4e44ae-ed72-4079-8691-1cb868c83cb8.mov

Safari

https://user-images.githubusercontent.com/84343285/178375729-4fb262d3-a3ba-474f-9728-ce392319be81.mov



### A11y
No A11y involvement