### PR TITLE
Fixing the scroll logic when it comes to root element

### DIFF
--- a/ui/library/src/utils/ScrollDirectionDetector.ts
+++ b/ui/library/src/utils/ScrollDirectionDetector.ts
@@ -18,10 +18,18 @@ export default class ScrollDetector {
   }
 
   attachScrollListener(): void {
+    if (this._el.tagName === 'HTML') {
+      window.addEventListener('scroll', this._onScroll, false);
+      return;
+    }
     this._el.addEventListener('scroll', this._onScroll, false);
   }
 
   detachScrollListener(): void {
+    if (this._el.tagName === 'HTML') {
+      window.removeEventListener('scroll', this._onScroll, false);
+      return;
+    }
     this._el.removeEventListener('scroll', this._onScroll, false);
   }
 

--- a/ui/library/src/utils/ScrollDirectionDetector.ts
+++ b/ui/library/src/utils/ScrollDirectionDetector.ts
@@ -18,7 +18,7 @@ export default class ScrollDetector {
   }
 
   attachScrollListener(): void {
-    if (this._el.tagName === 'HTML') {
+    if (this._el?.tagName?.toLowerCase() === 'html') {
       window.addEventListener('scroll', this._onScroll, false);
       return;
     }
@@ -26,7 +26,7 @@ export default class ScrollDetector {
   }
 
   detachScrollListener(): void {
-    if (this._el.tagName === 'HTML') {
+    if (this._el?.tagName?.toLowerCase() === 'html') {
       window.removeEventListener('scroll', this._onScroll, false);
       return;
     }


### PR DESCRIPTION
## Description
Ref: https://github.com/allenai/scholar/issues/32904

With the none `legacy_reader` layout the scroll is not existing in any of the react-pdf or S2 side any more but instead existing in browser level. This PR helps to unblock Eric from not be able to detect UP or DOWN when scrolling in none legacy layout


## Reviewer Instructions

Since the none legacy layout scroll is existing on browser so in the ScrollDirection `this._el.addEventListener` wont work for `document.documentElement`. Instead we have to use` window.addEventListener`

## Testing Plan

Run `yarn build `and copy the build file and paste into the node_module of S2 `@allenai/pdf-components `to verify if we console.log the scroll direction it should work.

## Output / Screenshots

https://user-images.githubusercontent.com/84343285/180267671-c3c045f9-5833-4f45-ae39-6810461807fd.mov



### A11y

No A11y involvement 