### PR TITLE
add scroll direction threshold and add is at top 

### DIFF
--- a/ui/library/src/context/ScrollContext.ts
+++ b/ui/library/src/context/ScrollContext.ts
@@ -77,7 +77,8 @@ export function useScrollContextProps(): IScrollContext {
   // Determine scroll direction
   const [scrollDirection, setScrollDirection] = React.useState<Nullable<ScrollDirection>>(null);
   const [scrollThreshold, setScrollThreshold] = React.useState<Nullable<number>>(null);
-  const [scrollThresholdReachedInDirection, setScrollThresholdReachedInDirection] = React.useState<Nullable<ScrollDirection>>(null);
+  const [scrollThresholdReachedInDirection, setScrollThresholdReachedInDirection] =
+    React.useState<Nullable<ScrollDirection>>(null);
   const [isAtTop, setIsAtTop] = React.useState<Nullable<boolean>>(null);
 
   React.useEffect(() => {
@@ -86,16 +87,17 @@ export function useScrollContextProps(): IScrollContext {
       return;
     }
 
-    let scrollDirectionDetector: ScrollDetector; 
-    if (!scrollThreshold) { // scroll threshold is optional
+    let scrollDirectionDetector: ScrollDetector;
+    if (!scrollThreshold) {
+      // scroll threshold is optional
       scrollDirectionDetector = new ScrollDetector(scrollElem, setScrollDirection, setIsAtTop);
     } else {
       scrollDirectionDetector = new ScrollDetector(
         scrollElem,
         setScrollDirection,
-        setIsAtTop, 
+        setIsAtTop,
         setScrollThresholdReachedInDirection,
-        scrollThreshold, 
+        scrollThreshold
       );
     }
 
@@ -217,9 +219,9 @@ export function useScrollContextProps(): IScrollContext {
     visiblePageNumbers,
     resetScrollObservers,
     setScrollRoot,
-    scrollToPage, 
+    scrollToPage,
     setScrollThreshold,
     scrollThresholdReachedInDirection,
-    isAtTop, 
+    isAtTop,
   };
 }

--- a/ui/library/src/utils/ScrollDirectionDetector.ts
+++ b/ui/library/src/utils/ScrollDirectionDetector.ts
@@ -10,7 +10,7 @@ export default class ScrollDetector {
   _el: Element;
   _setScrollDirection: (scrollDirection: ScrollDirection) => any;
   _lastScrollTopBeforeDirectionChange: number;
-  _scrollThreshold?: number; 
+  _scrollThreshold?: number;
   _isScrollThresholdReachedInDirection: Nullable<ScrollDirection>;
   _setScrollThresholdReachedInDirection?: (scrollDirection: Nullable<ScrollDirection>) => any;
   _isAtTop: Nullable<boolean>;
@@ -19,9 +19,9 @@ export default class ScrollDetector {
   constructor(
     el: Element,
     setScrollDirection: (scrollDirection: ScrollDirection) => any,
-    setIsAtTop: (isAtTop: boolean) => any, 
+    setIsAtTop: (isAtTop: boolean) => any,
     setScrollThresholdReachedInDirection?: (scrollDirection: Nullable<ScrollDirection>) => any,
-    scrollThreshold?: number,  
+    scrollThreshold?: number
   ) {
     this._el = el;
     this._lastScrollTop = this._el.scrollTop;
@@ -30,8 +30,8 @@ export default class ScrollDetector {
     this._isAtTop = null;
     this._setIsAtTop = setIsAtTop;
     this._lastScrollTopBeforeDirectionChange = this._el.scrollTop;
-    this._scrollThreshold = scrollThreshold; 
- 
+    this._scrollThreshold = scrollThreshold;
+
     this._isScrollThresholdReachedInDirection = null;
     this._setScrollThresholdReachedInDirection = setScrollThresholdReachedInDirection;
   }
@@ -54,9 +54,9 @@ export default class ScrollDetector {
 
   _onScroll = (): void => {
     const currScrollTop = this._el.scrollTop;
-    if (this._isAtTop !== (currScrollTop === 0)){
+    if (this._isAtTop !== (currScrollTop === 0)) {
       this._isAtTop = currScrollTop === 0;
-      this._setIsAtTop(currScrollTop === 0); 
+      this._setIsAtTop(currScrollTop === 0);
     }
     if (this._lastScrollTop === currScrollTop) {
       return;
@@ -77,19 +77,21 @@ export default class ScrollDetector {
       this._setScrollDirection(currScrollDirection);
 
       this._lastScrollTopBeforeDirectionChange = currScrollTop;
-      this._isScrollThresholdReachedInDirection = null; 
-      if(this._setScrollThresholdReachedInDirection !== undefined && !this._isAtTop) {
+      this._isScrollThresholdReachedInDirection = null;
+      if (this._setScrollThresholdReachedInDirection !== undefined && !this._isAtTop) {
         this._setScrollThresholdReachedInDirection(null);
       }
-
     } else {
-      if(this._scrollThreshold !== undefined && this._setScrollThresholdReachedInDirection !== undefined) {
+      if (
+        this._scrollThreshold !== undefined &&
+        this._setScrollThresholdReachedInDirection !== undefined
+      ) {
         const scrolledAmount = Math.abs(this._lastScrollTopBeforeDirectionChange - currScrollTop);
-        if(scrolledAmount >= this._scrollThreshold) {
-          this._isScrollThresholdReachedInDirection = this._lastScrollDirection; 
+        if (scrolledAmount >= this._scrollThreshold) {
+          this._isScrollThresholdReachedInDirection = this._lastScrollDirection;
           this._setScrollThresholdReachedInDirection(this._lastScrollDirection);
         }
-      } 
+      }
     }
-  }; 
+  };
 }

--- a/ui/library/src/utils/ScrollDirectionDetector.ts
+++ b/ui/library/src/utils/ScrollDirectionDetector.ts
@@ -78,14 +78,11 @@ export default class ScrollDetector {
 
       this._lastScrollTopBeforeDirectionChange = currScrollTop;
       this._isScrollThresholdReachedInDirection = null;
-      if (this._setScrollThresholdReachedInDirection !== undefined && !this._isAtTop) {
+      if (this._setScrollThresholdReachedInDirection && !this._isAtTop) {
         this._setScrollThresholdReachedInDirection(null);
       }
     } else {
-      if (
-        this._scrollThreshold !== undefined &&
-        this._setScrollThresholdReachedInDirection !== undefined
-      ) {
+      if (this._scrollThreshold && this._setScrollThresholdReachedInDirection) {
         const scrolledAmount = Math.abs(this._lastScrollTopBeforeDirectionChange - currScrollTop);
         if (scrolledAmount >= this._scrollThreshold) {
           this._isScrollThresholdReachedInDirection = this._lastScrollDirection;

--- a/ui/library/src/utils/ScrollDirectionDetector.ts
+++ b/ui/library/src/utils/ScrollDirectionDetector.ts
@@ -9,12 +9,31 @@ export default class ScrollDetector {
   _lastScrollDirection: Nullable<ScrollDirection>;
   _el: Element;
   _setScrollDirection: (scrollDirection: ScrollDirection) => any;
+  _lastScrollTopBeforeDirectionChange: number;
+  _scrollThreshold?: number; 
+  _isScrollThresholdReachedInDirection: Nullable<ScrollDirection>;
+  _setScrollThresholdReachedInDirection?: (scrollDirection: Nullable<ScrollDirection>) => any;
+  _isAtTop: Nullable<boolean>;
+  _setIsAtTop: (isAtTop: boolean) => any;
 
-  constructor(el: Element, setScrollDirection: (scrollDirection: ScrollDirection) => any) {
+  constructor(
+    el: Element,
+    setScrollDirection: (scrollDirection: ScrollDirection) => any,
+    setIsAtTop: (isAtTop: boolean) => any, 
+    setScrollThresholdReachedInDirection?: (scrollDirection: Nullable<ScrollDirection>) => any,
+    scrollThreshold?: number,  
+  ) {
     this._el = el;
     this._lastScrollTop = this._el.scrollTop;
     this._lastScrollDirection = null;
     this._setScrollDirection = setScrollDirection;
+    this._isAtTop = null;
+    this._setIsAtTop = setIsAtTop;
+    this._lastScrollTopBeforeDirectionChange = this._el.scrollTop;
+    this._scrollThreshold = scrollThreshold; 
+ 
+    this._isScrollThresholdReachedInDirection = null;
+    this._setScrollThresholdReachedInDirection = setScrollThresholdReachedInDirection;
   }
 
   attachScrollListener(): void {
@@ -35,6 +54,10 @@ export default class ScrollDetector {
 
   _onScroll = (): void => {
     const currScrollTop = this._el.scrollTop;
+    if (this._isAtTop !== (currScrollTop === 0)){
+      this._isAtTop = currScrollTop === 0;
+      this._setIsAtTop(currScrollTop === 0); 
+    }
     if (this._lastScrollTop === currScrollTop) {
       return;
     }
@@ -52,6 +75,21 @@ export default class ScrollDetector {
     if (this._lastScrollDirection !== currScrollDirection) {
       this._lastScrollDirection = currScrollDirection;
       this._setScrollDirection(currScrollDirection);
+
+      this._lastScrollTopBeforeDirectionChange = currScrollTop;
+      this._isScrollThresholdReachedInDirection = null; 
+      if(this._setScrollThresholdReachedInDirection !== undefined && !this._isAtTop) {
+        this._setScrollThresholdReachedInDirection(null);
+      }
+
+    } else {
+      if(this._scrollThreshold !== undefined && this._setScrollThresholdReachedInDirection !== undefined) {
+        const scrolledAmount = Math.abs(this._lastScrollTopBeforeDirectionChange - currScrollTop);
+        if(scrolledAmount >= this._scrollThreshold) {
+          this._isScrollThresholdReachedInDirection = this._lastScrollDirection; 
+          this._setScrollThresholdReachedInDirection(this._lastScrollDirection);
+        }
+      } 
     }
-  };
+  }; 
 }

--- a/ui/library/test/utils/scrollDirectionDetector.test.ts
+++ b/ui/library/test/utils/scrollDirectionDetector.test.ts
@@ -21,7 +21,11 @@ describe('scrollDirectionDetector', () => {
       scrollDirection = direction;
     }
 
-    const scrollDirectionDetector = new ScrollDetector(mockScroll as any, setScrollDirection, ()=>undefined);
+    const scrollDirectionDetector = new ScrollDetector(
+      mockScroll as any,
+      setScrollDirection,
+      () => undefined
+    );
     scrollDirectionDetector._onScroll();
 
     expect(scrollDirection).to.equal(null);
@@ -44,7 +48,11 @@ describe('scrollDirectionDetector', () => {
       scrollDirection = direction;
     }
 
-    const scrollDirectionDetector = new ScrollDetector(mockScroll as any, setScrollDirection, ()=>undefined);
+    const scrollDirectionDetector = new ScrollDetector(
+      mockScroll as any,
+      setScrollDirection,
+      () => undefined
+    );
     mockScroll.scrollTop = 110;
     scrollDirectionDetector._onScroll();
 
@@ -68,7 +76,11 @@ describe('scrollDirectionDetector', () => {
       scrollDirection = direction;
     }
 
-    const scrollDirectionDetector = new ScrollDetector(mockScroll as any, setScrollDirection, ()=>undefined);
+    const scrollDirectionDetector = new ScrollDetector(
+      mockScroll as any,
+      setScrollDirection,
+      () => undefined
+    );
     mockScroll.scrollTop = 100;
     scrollDirectionDetector._onScroll();
 
@@ -92,7 +104,11 @@ describe('scrollDirectionDetector', () => {
       scrollDirection = direction;
     }
 
-    const scrollDirectionDetector = new ScrollDetector(mockScroll as any, setScrollDirection, ()=>undefined);
+    const scrollDirectionDetector = new ScrollDetector(
+      mockScroll as any,
+      setScrollDirection,
+      () => undefined
+    );
     mockScroll.scrollTop = 110;
     scrollDirectionDetector._onScroll();
 
@@ -121,7 +137,11 @@ describe('scrollDirectionDetector', () => {
       scrollDirection = direction;
     }
 
-    const scrollDirectionDetector = new ScrollDetector(mockScroll as any, setScrollDirection, ()=>undefined);
+    const scrollDirectionDetector = new ScrollDetector(
+      mockScroll as any,
+      setScrollDirection,
+      () => undefined
+    );
     mockScroll.scrollTop = 90;
     scrollDirectionDetector._onScroll();
 
@@ -150,7 +170,11 @@ describe('scrollDirectionDetector', () => {
       scrollDirection = direction;
     }
 
-    const scrollDirectionDetector = new ScrollDetector(mockScroll as any, setScrollDirection, ()=>undefined);
+    const scrollDirectionDetector = new ScrollDetector(
+      mockScroll as any,
+      setScrollDirection,
+      () => undefined
+    );
     mockScroll.scrollTop = 110;
     scrollDirectionDetector._onScroll();
 
@@ -179,7 +203,11 @@ describe('scrollDirectionDetector', () => {
       scrollDirection = direction;
     }
 
-    const scrollDirectionDetector = new ScrollDetector(mockScroll as any, setScrollDirection, ()=>undefined);
+    const scrollDirectionDetector = new ScrollDetector(
+      mockScroll as any,
+      setScrollDirection,
+      () => undefined
+    );
     mockScroll.scrollTop = 90;
     scrollDirectionDetector._onScroll();
 
@@ -269,22 +297,19 @@ describe('scrollDirectionDetector', () => {
     );
 
     scrollDirectionDetector._onScroll();
-    expect(isAtTop, "isAtTop defaults to true at top of page").to.equal(true);
+    expect(isAtTop, 'isAtTop defaults to true at top of page').to.equal(true);
 
     mockScroll.scrollTop = 100;
     scrollDirectionDetector._onScroll();
-    expect(isAtTop, "isAtTop is false since we scrolled down").to.equal(false);
+    expect(isAtTop, 'isAtTop is false since we scrolled down').to.equal(false);
 
     mockScroll.scrollTop = 0;
     scrollDirectionDetector._onScroll();
-    expect(isAtTop, "isAtTop is true again since we scrolled all the way up").to.equal(true); 
+    expect(isAtTop, 'isAtTop is true again since we scrolled all the way up').to.equal(true);
   });
-
-
 
   // test threshold
 
- 
   it('scrollThresholdReachedInDirection defaults to null on start', () => {
     const mockScroll = {
       scrollTop: 0,
@@ -302,13 +327,13 @@ describe('scrollDirectionDetector', () => {
     function setScrollThresholdReachedInDirection(dir: Nullable<ScrollDirection>) {
       scrollThresholdReachedInDirection = dir;
     }
- 
+
     const scrollDirectionDetector = new ScrollDetector(
       mockScroll as any,
       () => undefined,
-      () => undefined, 
+      () => undefined,
       setScrollThresholdReachedInDirection,
-      scrollThreshold,
+      scrollThreshold
     );
     scrollDirectionDetector._onScroll();
 
@@ -332,37 +357,48 @@ describe('scrollDirectionDetector', () => {
     function setScrollThresholdReachedInDirection(dir: Nullable<ScrollDirection>) {
       scrollThresholdReachedInDirection = dir;
     }
- 
+
     const scrollDirectionDetector = new ScrollDetector(
       mockScroll as any,
       () => undefined,
-      () => undefined, 
+      () => undefined,
       setScrollThresholdReachedInDirection,
-      scrollThreshold,
+      scrollThreshold
     );
     scrollDirectionDetector._onScroll();
-    expect(scrollThresholdReachedInDirection, "scrollThresholdReachedInDirection defults to null").to.equal(null);
+    expect(
+      scrollThresholdReachedInDirection,
+      'scrollThresholdReachedInDirection defults to null'
+    ).to.equal(null);
 
-    mockScroll.scrollTop = 1;  // have to do this with mockscroll
+    mockScroll.scrollTop = 1; // have to do this with mockscroll
     scrollDirectionDetector._onScroll();
 
-    mockScroll.scrollTop = 25;  
+    mockScroll.scrollTop = 25;
     scrollDirectionDetector._onScroll();
-    expect(scrollThresholdReachedInDirection, "scrolled down but not enough to hit threshold so is still null").to.equal(null);
+    expect(
+      scrollThresholdReachedInDirection,
+      'scrolled down but not enough to hit threshold so is still null'
+    ).to.equal(null);
 
-    mockScroll.scrollTop = 51;  
+    mockScroll.scrollTop = 51;
     scrollDirectionDetector._onScroll();
-    expect(scrollThresholdReachedInDirection, "scrolled down enough to hit threshold and return DOWN").to.equal(ScrollDirection.DOWN);
+    expect(
+      scrollThresholdReachedInDirection,
+      'scrolled down enough to hit threshold and return DOWN'
+    ).to.equal(ScrollDirection.DOWN);
 
-    mockScroll.scrollTop = 60;  // make some room
+    mockScroll.scrollTop = 60; // make some room
     scrollDirectionDetector._onScroll();
 
-    mockScroll.scrollTop = 59;  // have to do this with mockscroll
+    mockScroll.scrollTop = 59; // have to do this with mockscroll
     scrollDirectionDetector._onScroll();
-  
-    mockScroll.scrollTop = 9;  
-    scrollDirectionDetector._onScroll(); 
-    expect(scrollThresholdReachedInDirection, "scrolled up enough to hit threshold and return UP").to.equal(ScrollDirection.UP);
+
+    mockScroll.scrollTop = 9;
+    scrollDirectionDetector._onScroll();
+    expect(
+      scrollThresholdReachedInDirection,
+      'scrolled up enough to hit threshold and return UP'
+    ).to.equal(ScrollDirection.UP);
   });
- 
 });

--- a/ui/library/test/utils/scrollDirectionDetector.test.ts
+++ b/ui/library/test/utils/scrollDirectionDetector.test.ts
@@ -21,7 +21,7 @@ describe('scrollDirectionDetector', () => {
       scrollDirection = direction;
     }
 
-    const scrollDirectionDetector = new ScrollDetector(mockScroll as any, setScrollDirection);
+    const scrollDirectionDetector = new ScrollDetector(mockScroll as any, setScrollDirection, ()=>undefined);
     scrollDirectionDetector._onScroll();
 
     expect(scrollDirection).to.equal(null);
@@ -44,7 +44,7 @@ describe('scrollDirectionDetector', () => {
       scrollDirection = direction;
     }
 
-    const scrollDirectionDetector = new ScrollDetector(mockScroll as any, setScrollDirection);
+    const scrollDirectionDetector = new ScrollDetector(mockScroll as any, setScrollDirection, ()=>undefined);
     mockScroll.scrollTop = 110;
     scrollDirectionDetector._onScroll();
 
@@ -68,7 +68,7 @@ describe('scrollDirectionDetector', () => {
       scrollDirection = direction;
     }
 
-    const scrollDirectionDetector = new ScrollDetector(mockScroll as any, setScrollDirection);
+    const scrollDirectionDetector = new ScrollDetector(mockScroll as any, setScrollDirection, ()=>undefined);
     mockScroll.scrollTop = 100;
     scrollDirectionDetector._onScroll();
 
@@ -92,7 +92,7 @@ describe('scrollDirectionDetector', () => {
       scrollDirection = direction;
     }
 
-    const scrollDirectionDetector = new ScrollDetector(mockScroll as any, setScrollDirection);
+    const scrollDirectionDetector = new ScrollDetector(mockScroll as any, setScrollDirection, ()=>undefined);
     mockScroll.scrollTop = 110;
     scrollDirectionDetector._onScroll();
 
@@ -121,7 +121,7 @@ describe('scrollDirectionDetector', () => {
       scrollDirection = direction;
     }
 
-    const scrollDirectionDetector = new ScrollDetector(mockScroll as any, setScrollDirection);
+    const scrollDirectionDetector = new ScrollDetector(mockScroll as any, setScrollDirection, ()=>undefined);
     mockScroll.scrollTop = 90;
     scrollDirectionDetector._onScroll();
 
@@ -150,7 +150,7 @@ describe('scrollDirectionDetector', () => {
       scrollDirection = direction;
     }
 
-    const scrollDirectionDetector = new ScrollDetector(mockScroll as any, setScrollDirection);
+    const scrollDirectionDetector = new ScrollDetector(mockScroll as any, setScrollDirection, ()=>undefined);
     mockScroll.scrollTop = 110;
     scrollDirectionDetector._onScroll();
 
@@ -179,7 +179,7 @@ describe('scrollDirectionDetector', () => {
       scrollDirection = direction;
     }
 
-    const scrollDirectionDetector = new ScrollDetector(mockScroll as any, setScrollDirection);
+    const scrollDirectionDetector = new ScrollDetector(mockScroll as any, setScrollDirection, ()=>undefined);
     mockScroll.scrollTop = 90;
     scrollDirectionDetector._onScroll();
 

--- a/ui/library/test/utils/scrollDirectionDetector.test.ts
+++ b/ui/library/test/utils/scrollDirectionDetector.test.ts
@@ -190,4 +190,179 @@ describe('scrollDirectionDetector', () => {
 
     expect(scrollDirection, 'then continue to scroll up').to.equal(ScrollDirection.UP);
   });
+
+  it('isAtTop defaults to true if page starts at top', () => {
+    const mockScroll = {
+      scrollTop: 0,
+      addEventListener: (eventName, callback) => {
+        if (eventName === 'scroll') {
+          callback();
+        }
+      },
+      removeEventListener: () => undefined,
+      querySelectorAll: () => [],
+    };
+
+    let isAtTop: Nullable<boolean> = null;
+    function setIsAtTop(top: boolean) {
+      isAtTop = top;
+    }
+
+    const scrollDirectionDetector = new ScrollDetector(
+      mockScroll as any,
+      () => undefined,
+      setIsAtTop
+    );
+    scrollDirectionDetector._onScroll();
+
+    expect(isAtTop).to.equal(true);
+  });
+
+  it('isAtTop defaults to false if page starts in middle', () => {
+    const mockScroll = {
+      scrollTop: 50,
+      addEventListener: (eventName, callback) => {
+        if (eventName === 'scroll') {
+          callback();
+        }
+      },
+      removeEventListener: () => undefined,
+      querySelectorAll: () => [],
+    };
+
+    let isAtTop: Nullable<boolean> = null;
+    function setIsAtTop(top: boolean) {
+      isAtTop = top;
+    }
+
+    const scrollDirectionDetector = new ScrollDetector(
+      mockScroll as any,
+      () => undefined,
+      setIsAtTop
+    );
+    scrollDirectionDetector._onScroll();
+
+    expect(isAtTop).to.equal(false);
+  });
+
+  it('isAtTop is true after scrolling down then all the way up', () => {
+    const mockScroll = {
+      scrollTop: 0,
+      addEventListener: (eventName, callback) => {
+        if (eventName === 'scroll') {
+          callback();
+        }
+      },
+      removeEventListener: () => undefined,
+      querySelectorAll: () => [],
+    };
+
+    let isAtTop: Nullable<boolean> = null;
+    function setIsAtTop(top: boolean) {
+      isAtTop = top;
+    }
+
+    const scrollDirectionDetector = new ScrollDetector(
+      mockScroll as any,
+      () => undefined,
+      setIsAtTop
+    );
+
+    scrollDirectionDetector._onScroll();
+    expect(isAtTop, "isAtTop defaults to true at top of page").to.equal(true);
+
+    mockScroll.scrollTop = 100;
+    scrollDirectionDetector._onScroll();
+    expect(isAtTop, "isAtTop is false since we scrolled down").to.equal(false);
+
+    mockScroll.scrollTop = 0;
+    scrollDirectionDetector._onScroll();
+    expect(isAtTop, "isAtTop is true again since we scrolled all the way up").to.equal(true); 
+  });
+
+
+
+  // test threshold
+
+ 
+  it('scrollThresholdReachedInDirection defaults to null on start', () => {
+    const mockScroll = {
+      scrollTop: 0,
+      addEventListener: (eventName, callback) => {
+        if (eventName === 'scroll') {
+          callback();
+        }
+      },
+      removeEventListener: () => undefined,
+      querySelectorAll: () => [],
+    };
+
+    const scrollThreshold = 50;
+    let scrollThresholdReachedInDirection: Nullable<ScrollDirection> = null;
+    function setScrollThresholdReachedInDirection(dir: Nullable<ScrollDirection>) {
+      scrollThresholdReachedInDirection = dir;
+    }
+ 
+    const scrollDirectionDetector = new ScrollDetector(
+      mockScroll as any,
+      () => undefined,
+      () => undefined, 
+      setScrollThresholdReachedInDirection,
+      scrollThreshold,
+    );
+    scrollDirectionDetector._onScroll();
+
+    expect(scrollThresholdReachedInDirection).to.equal(null);
+  });
+
+  it('scrollThresholdReachedInDirection is null until reaching threshold and returns correct direction in both directions', () => {
+    const mockScroll = {
+      scrollTop: 0,
+      addEventListener: (eventName, callback) => {
+        if (eventName === 'scroll') {
+          callback();
+        }
+      },
+      removeEventListener: () => undefined,
+      querySelectorAll: () => [],
+    };
+
+    const scrollThreshold = 50;
+    let scrollThresholdReachedInDirection: Nullable<ScrollDirection> = null;
+    function setScrollThresholdReachedInDirection(dir: Nullable<ScrollDirection>) {
+      scrollThresholdReachedInDirection = dir;
+    }
+ 
+    const scrollDirectionDetector = new ScrollDetector(
+      mockScroll as any,
+      () => undefined,
+      () => undefined, 
+      setScrollThresholdReachedInDirection,
+      scrollThreshold,
+    );
+    scrollDirectionDetector._onScroll();
+    expect(scrollThresholdReachedInDirection, "scrollThresholdReachedInDirection defults to null").to.equal(null);
+
+    mockScroll.scrollTop = 1;  // have to do this with mockscroll
+    scrollDirectionDetector._onScroll();
+
+    mockScroll.scrollTop = 25;  
+    scrollDirectionDetector._onScroll();
+    expect(scrollThresholdReachedInDirection, "scrolled down but not enough to hit threshold so is still null").to.equal(null);
+
+    mockScroll.scrollTop = 51;  
+    scrollDirectionDetector._onScroll();
+    expect(scrollThresholdReachedInDirection, "scrolled down enough to hit threshold and return DOWN").to.equal(ScrollDirection.DOWN);
+
+    mockScroll.scrollTop = 60;  // make some room
+    scrollDirectionDetector._onScroll();
+
+    mockScroll.scrollTop = 59;  // have to do this with mockscroll
+    scrollDirectionDetector._onScroll();
+  
+    mockScroll.scrollTop = 9;  
+    scrollDirectionDetector._onScroll(); 
+    expect(scrollThresholdReachedInDirection, "scrolled up enough to hit threshold and return UP").to.equal(ScrollDirection.UP);
+  });
+ 
 });


### PR DESCRIPTION
Added 2 new features I needed to make a partial persistent header. scrollDirectionThreshold lets you optionally set a threshold and if you scroll that much, it will tell you in which direction. Also added isAtTop to tell you if you are scrolled to the top of the page