### PR TITLE
Add logic for detecting current page & outline in ScrollContext In PDF Component

### DIFF
--- a/ui/demo/less/reader.less
+++ b/ui/demo/less/reader.less
@@ -73,15 +73,3 @@ body {
   }
 }
 
-.reader__outline-item {
-  > a {
-    transition: filter 200ms ease-in-out;
-  }
-  &.reader__outline-item--target-visible {
-    > a {
-      filter: hue-rotate(45deg);
-      transition-duration: 400ms;
-    }
-  }
-}
-

--- a/ui/demo/less/reader.less
+++ b/ui/demo/less/reader.less
@@ -72,3 +72,16 @@ body {
     font-weight: 300;
   }
 }
+
+.reader__outline-item {
+  > a {
+    transition: filter 200ms ease-in-out;
+  }
+  &.reader__outline-item--target-visible {
+    > a {
+      filter: hue-rotate(45deg);
+      transition-duration: 400ms;
+    }
+  }
+}
+

--- a/ui/library/less/styles.less
+++ b/ui/library/less/styles.less
@@ -1,7 +1,7 @@
 @bounding-box-border: 2px dotted @initial-blue;
 
 .reader__page {
-  background-color: @pdflib-page-background;
+  background: @pdflib-page-background center center / cover no-repeat;
   margin: 24px;
   box-shadow: 0px 4px 14px fade(@pdflib-page-shadow, 20%);
   flex: 1 0 auto;
@@ -59,8 +59,13 @@
   z-index: @z-index-bounding-box-overlay;
 }
 
+.reader__page__outline-target {
+  position: absolute;
+  visibility: hidden;
+}
+
 .react-pdf__Page {
-  height: 100%; // Causes the page to fill the flex parent
+  height: 100%;
 }
 
 // HACK: avoid mis-alignment of selected texts

--- a/ui/library/src/components/DocumentWrapper.tsx
+++ b/ui/library/src/components/DocumentWrapper.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Document, DocumentProps, pdfjs } from 'react-pdf';
 
 import { DocumentContext } from '../context/DocumentContext';
+import { ScrollContext } from '../context/ScrollContext';
 import { TransformContext } from '../context/TransformContext';
 import { UiContext } from '../context/UiContext';
 import { getErrorMessage } from '../utils/errorMessage';
@@ -22,6 +23,7 @@ export const DocumentWrapper: React.FunctionComponent<Props> = ({
 
   const { pdfDocProxy, setNumPages, setPageDimensions, setPdfDocProxy } =
     React.useContext(DocumentContext);
+  const { resetScrollObservers } = React.useContext(ScrollContext);
   const { rotation } = React.useContext(TransformContext);
   const { setErrorMessage, setIsLoading } = React.useContext(UiContext);
 
@@ -29,6 +31,10 @@ export const DocumentWrapper: React.FunctionComponent<Props> = ({
     // getPage uses 1-indexed pageNumber, not 0-indexed pageIndex
     return pdfDoc.getPage(1);
   }
+
+  React.useEffect(() => {
+    resetScrollObservers();
+  }, []);
 
   const onPdfLoadSuccess = React.useCallback((pdfDoc: pdfjs.PDFDocumentProxy): void => {
     setNumPages(pdfDoc.numPages);

--- a/ui/library/src/components/PageWrapper.tsx
+++ b/ui/library/src/components/PageWrapper.tsx
@@ -1,3 +1,4 @@
+import classnames from 'classnames';
 import * as React from 'react';
 import { Page } from 'react-pdf';
 import { RenderFunction } from 'react-pdf/dist/Page';
@@ -41,13 +42,14 @@ export const PageWrapper: React.FunctionComponent<Props> = ({
     return null;
   }
 
+  const getPageStyle = React.useCallback(() => {
+    const styles: Record<string, unknown> = computePageStyle(pageDimensions, rotation, scale);
+    return styles;
+  }, [pageDimensions, rotation, scale]);
+
   const getWidth = React.useCallback(() => {
     return getPageWidth(pageDimensions, rotation);
   }, [pageDimensions, rotation]);
-
-  const getPageStyle = React.useCallback(() => {
-    return computePageStyle(pageDimensions, rotation, scale);
-  }, [pageDimensions, rotation, scale]);
 
   const outlineTargets = getOutlineTargets({ pageIndex, scale, rotation, pageDimensions });
 
@@ -56,9 +58,8 @@ export const PageWrapper: React.FunctionComponent<Props> = ({
   // TODO: Can we CSS this to auto-shrink?
   return (
     <div
-      data-page-number={pageIndex + 1}
       id={generatePageIdFromIndex(pageIndex)}
-      className="reader__page"
+      className={classnames('reader__page')}
       style={getPageStyle()}
       {...extraProps}>
       {children}

--- a/ui/library/src/components/PageWrapper.tsx
+++ b/ui/library/src/components/PageWrapper.tsx
@@ -1,4 +1,3 @@
-import classnames from 'classnames';
 import * as React from 'react';
 import { Page } from 'react-pdf';
 import { RenderFunction } from 'react-pdf/dist/Page';
@@ -59,7 +58,7 @@ export const PageWrapper: React.FunctionComponent<Props> = ({
   return (
     <div
       id={generatePageIdFromIndex(pageIndex)}
-      className={classnames('reader__page')}
+      className="reader__page"
       style={getPageStyle()}
       {...extraProps}>
       {children}

--- a/ui/library/src/components/PageWrapper.tsx
+++ b/ui/library/src/components/PageWrapper.tsx
@@ -33,7 +33,7 @@ export const PageWrapper: React.FunctionComponent<Props> = ({
   ...extraProps
 }: Props) => {
   const { rotation, scale } = React.useContext(TransformContext);
-  const { pageDimensions } = React.useContext(DocumentContext);
+  const { pageDimensions, getOutlineTargets } = React.useContext(DocumentContext);
 
   // Don't display until we have page size data
   // TODO: Handle this nicer so we display either the loading or error treatment
@@ -49,11 +49,14 @@ export const PageWrapper: React.FunctionComponent<Props> = ({
     return computePageStyle(pageDimensions, rotation, scale);
   }, [pageDimensions, rotation, scale]);
 
+  const outlineTargets = getOutlineTargets({ pageIndex, scale, rotation, pageDimensions });
+
   // Width needs to be set to prevent the outermost Page div from extending to fit the parent,
   // and mis-aligning the text layer.
   // TODO: Can we CSS this to auto-shrink?
   return (
     <div
+      data-page-number={pageIndex + 1}
       id={generatePageIdFromIndex(pageIndex)}
       className="reader__page"
       style={getPageStyle()}
@@ -69,6 +72,16 @@ export const PageWrapper: React.FunctionComponent<Props> = ({
         rotate={rotation}
         renderAnnotationLayer={true}
       />
+      <div className="reader__page__outline-targets">
+        {outlineTargets.map(({ dest, leftPx, topPx }) => (
+          <span
+            key={dest}
+            className="reader__page__outline-target"
+            data-outline-target-dest={dest}
+            style={{ left: leftPx + 'px', top: topPx + 'px' }}
+          />
+        ))}
+      </div>
     </div>
   );
 };

--- a/ui/library/src/components/outline/Outline.tsx
+++ b/ui/library/src/components/outline/Outline.tsx
@@ -10,14 +10,15 @@ export const Outline: React.FunctionComponent = ({ ...extraProps }) => {
     React.useContext(DocumentContext);
   const { scrollToOutlineTarget, resetScrollObservers } = React.useContext(ScrollContext);
 
-  if (!pdfDocProxy) {
-    return null;
-  }
-
   React.useEffect(() => {
     if (outline) {
       return;
     }
+
+    if (!pdfDocProxy) {
+      return;
+    }
+
     pdfDocProxy
       .getOutline()
       .then((outlineArray: Array<OutlineNode>) => {
@@ -32,13 +33,17 @@ export const Outline: React.FunctionComponent = ({ ...extraProps }) => {
       });
   }, [outline]);
 
-  const clickHandler = (dest: NodeDestination): void => {
+  const clickHandler = React.useCallback((dest: NodeDestination): void => {
     if (!dest) {
       return;
     }
     scrollToOutlineTarget(dest);
     return;
-  };
+  }, []);
+
+  if (!pdfDocProxy) {
+    return null;
+  }
 
   return (
     <div className="reader__outline" {...extraProps}>

--- a/ui/library/src/components/outline/Outline.tsx
+++ b/ui/library/src/components/outline/Outline.tsx
@@ -1,50 +1,43 @@
 import * as React from 'react';
 
-import { DocumentContext } from '../../context/DocumentContext';
-import { TransformContext } from '../../context/TransformContext';
-import { scrollToPosition } from '../../utils/scroll';
-import { Ref } from '../types/destination';
+import { buildOutlinePositions, DocumentContext } from '../../context/DocumentContext';
+import { ScrollContext } from '../../context/ScrollContext';
 import { NodeDestination, OutlineNode } from '../types/outline';
 import { OutlineItem } from './OutlineItem';
 
 export const Outline: React.FunctionComponent = ({ ...extraProps }) => {
-  const { outline, pdfDocProxy, setOutline } = React.useContext(DocumentContext);
-  const { rotation } = React.useContext(TransformContext);
+  const { outline, pdfDocProxy, setOutline, setOutlinePositions } =
+    React.useContext(DocumentContext);
+  const { scrollToOutlineTarget, resetScrollObservers } = React.useContext(ScrollContext);
 
   if (!pdfDocProxy) {
     return null;
   }
 
-  if (!outline) {
-    pdfDocProxy.getOutline().then((outlineArray: Array<OutlineNode>) => {
-      setOutline(outlineArray);
-    });
-  }
+  React.useEffect(() => {
+    if (outline) {
+      return;
+    }
+    pdfDocProxy
+      .getOutline()
+      .then((outlineArray: Array<OutlineNode>) => {
+        setOutline(outlineArray);
+        return buildOutlinePositions(pdfDocProxy, outlineArray);
+      })
+      .then(outlinePositions => {
+        setOutlinePositions(outlinePositions);
+      })
+      .then(() => {
+        resetScrollObservers();
+      });
+  }, [outline]);
 
   const clickHandler = (dest: NodeDestination): void => {
     if (!dest) {
       return;
     }
-    pdfDocProxy.getDestination(dest.toString()).then(destArray => {
-      if (!destArray) {
-        return;
-      }
-      /*
-        destArray returned by getDestination contains 5 items:
-        1. Reference to the page where dest locates at
-        2. Types of dest; currently only "XYZ" is handled
-        3. X -- the distance from the left edge of a page to dest, measured in points
-        4. Y -- the distance from the bottom edge of a page to dest, measured in points
-        5. Scale
-        
-        Reference: https://github.com/mozilla/pdf.js/blob/d3e1d7090ac6f582d0c277e8768ac63bbbaa1134/web/base_viewer.js#L1152
-      */
-      // The second and the fifth items are left out intentionally for not being used in scrolling function.
-      const [ref, , , bottomPoints] = destArray;
-      pdfDocProxy.getPageIndex(new Ref(ref)).then(refInfo => {
-        scrollToPosition(parseInt(refInfo.toString()), 0, bottomPoints, rotation);
-      });
-    });
+    scrollToOutlineTarget(dest);
+    return;
   };
 
   return (

--- a/ui/library/src/components/outline/OutlineItem.tsx
+++ b/ui/library/src/components/outline/OutlineItem.tsx
@@ -1,5 +1,7 @@
+import classnames from 'classnames';
 import * as React from 'react';
 
+import { ScrollContext } from '../../context/ScrollContext';
 import { NodeDestination, OutlineNode } from '../types/outline';
 
 type Props = {
@@ -8,6 +10,8 @@ type Props = {
 };
 
 export const OutlineItem: React.FunctionComponent<Props> = ({ items, onClick }: Props) => {
+  const { isOutlineTargetVisible } = React.useContext(ScrollContext);
+
   if (!items || !items.length) {
     return null;
   }
@@ -22,7 +26,11 @@ export const OutlineItem: React.FunctionComponent<Props> = ({ items, onClick }: 
 
     // If an item has sub titles, render <OutlineItem />
     return (
-      <li key={item.title} className="reader__outline-item">
+      <li
+        key={item.dest?.toString() || item.title}
+        className={classnames('reader__outline-item', {
+          'reader__outline-item--target-visible': isOutlineTargetVisible(item.dest),
+        })}>
         <a href="#" onClick={clickHandler}>
           {item.title}
         </a>

--- a/ui/library/src/components/types/outline.ts
+++ b/ui/library/src/components/types/outline.ts
@@ -1,3 +1,5 @@
+import { PageRotation } from '../../utils/rotate';
+import { Dimensions } from './boundingBox';
 import { Nullable } from './utils';
 
 export type NodeDestination = Nullable<string> | any[];
@@ -12,4 +14,27 @@ export type OutlineNode = {
   newWindow: boolean | undefined;
   count: number | undefined;
   items: any[];
+};
+
+export type OutlinePosition = {
+  pageNumber: number;
+  dest: string;
+  leftPoint: number;
+  bottomPoint: number;
+};
+
+export type OutlinePositionsByPageNumberMap = Map<number, OutlinePosition[]>;
+
+export type OutlineTarget = {
+  dest: string;
+  leftPx: number;
+  topPx: number;
+};
+
+export type OutlineTargetArgs = {
+  pageNumber?: number;
+  pageIndex?: number;
+  scale: number;
+  rotation: PageRotation;
+  pageDimensions: Dimensions;
 };

--- a/ui/library/src/context/DocumentContext.ts
+++ b/ui/library/src/context/DocumentContext.ts
@@ -5,14 +5,40 @@ import { Dimensions } from '../components/types/boundingBox';
 import { OutlineNode } from '../components/types/outline';
 import { Nullable } from '../components/types/utils';
 import { logProviderWarning } from '../utils/provider';
+import { PageRotation } from '../utils/rotate';
+import { calculateTargetPosition } from '../utils/scroll';
+
+export type OutlinePosition = {
+  pageNumber: number;
+  dest: string;
+  leftPoint: number;
+  bottomPoint: number;
+};
+
+export type OutlinePositionsByPageNumberMap = Map<number, OutlinePosition[]>;
+
+export type OutlineTarget = {
+  dest: string;
+  leftPx: number;
+  topPx: number;
+};
 
 export interface IDocumentContext {
   numPages: number;
   outline: Nullable<Array<OutlineNode>>;
+  outlinePositions: Nullable<OutlinePositionsByPageNumberMap>;
   pageDimensions: Dimensions; // Scaled at 100%
   pdfDocProxy?: pdfjs.PDFDocumentProxy;
+  getOutlineTargets: (opts: {
+    pageNumber?: number;
+    pageIndex?: number;
+    scale: number;
+    rotation: PageRotation;
+    pageDimensions: Dimensions;
+  }) => OutlineTarget[];
   setNumPages: (numPages: number) => void;
   setOutline: (outline: Nullable<Array<OutlineNode>>) => void;
+  setOutlinePositions: (outlinePositions: Nullable<OutlinePositionsByPageNumberMap>) => void;
   setPageDimensions: (pageDimensions: Dimensions) => void;
   setPdfDocProxy: (pdfDocProxy: pdfjs.PDFDocumentProxy) => void;
 }
@@ -20,13 +46,21 @@ export interface IDocumentContext {
 export const DocumentContext = React.createContext<IDocumentContext>({
   numPages: 0,
   outline: [],
+  outlinePositions: null,
   pageDimensions: { height: 0, width: 0 },
   pdfDocProxy: undefined,
+  getOutlineTargets: opts => {
+    logProviderWarning(`getOutlineTargets(${JSON.stringify(opts)})`, 'DocumentContext');
+    return [];
+  },
   setNumPages: numPages => {
     logProviderWarning(`setNumPages(${numPages})`, 'DocumentContext');
   },
   setOutline: outline => {
     logProviderWarning(`setOutline(${outline})`, 'DocumentContext');
+  },
+  setOutlinePositions: outline => {
+    logProviderWarning(`setOutlinePositions(${outline})`, 'DocumentContext');
   },
   setPageDimensions: pageDimensions => {
     logProviderWarning(`setPageDimensions(${pageDimensions})`, 'DocumentContext');
@@ -39,17 +73,137 @@ export const DocumentContext = React.createContext<IDocumentContext>({
 export function useDocumentContextProps(): IDocumentContext {
   const [numPages, setNumPages] = React.useState<number>(0);
   const [outline, setOutline] = React.useState<Nullable<Array<OutlineNode>>>(null);
+  const [outlinePositions, setOutlinePositions] =
+    React.useState<Nullable<OutlinePositionsByPageNumberMap>>(null);
   const [pageDimensions, setPageDimensions] = React.useState<Dimensions>({ height: 0, width: 0 });
   const [pdfDocProxy, setPdfDocProxy] = React.useState<pdfjs.PDFDocumentProxy>();
+
+  const getOutlineTargets = React.useCallback(
+    ({
+      pageNumber,
+      pageIndex,
+      scale,
+      rotation,
+      pageDimensions,
+    }: {
+      pageNumber?: number;
+      pageIndex?: number;
+      scale: number;
+      rotation: PageRotation;
+      pageDimensions: Dimensions;
+    }): OutlineTarget[] => {
+      if (typeof pageIndex === 'number') {
+        pageNumber = pageIndex + 1;
+      }
+      if (typeof pageNumber !== 'number') {
+        return [];
+      }
+      const positions = outlinePositions?.get(pageNumber) || [];
+      return positions.map(({ dest, leftPoint, bottomPoint }) => {
+        const { leftPx, topPx } = calculateTargetPosition({
+          scale,
+          rotation,
+          leftPoint,
+          bottomPoint,
+          pageDimensions,
+        });
+        return {
+          dest,
+          leftPx,
+          topPx,
+        };
+      });
+    },
+    [outlinePositions]
+  );
 
   return {
     numPages,
     outline,
-    pageDimensions: pageDimensions,
+    outlinePositions,
+    pageDimensions,
     pdfDocProxy,
+    getOutlineTargets,
     setNumPages,
     setOutline,
+    setOutlinePositions,
     setPageDimensions: setPageDimensions,
     setPdfDocProxy,
   };
+}
+
+export async function buildOutlinePositions(
+  pdfDocProxy: pdfjs.PDFDocumentProxy,
+  outline?: OutlineNode[]
+): Promise<OutlinePositionsByPageNumberMap> {
+  if (!outline) {
+    outline = await pdfDocProxy.getOutline();
+  }
+
+  // Depth first search through outline items
+  const itemQueue = outline.slice();
+  const proms: Promise<Nullable<OutlinePosition>>[] = [];
+  while (itemQueue.length > 0) {
+    const item = itemQueue.pop();
+    if (!item) {
+      continue; // Not able to process
+    }
+    const { dest, items } = item;
+
+    // Add child items to queue
+    if (Array.isArray(items)) {
+      itemQueue.push(...items);
+    }
+
+    // Fetch destinations for item
+    if (Array.isArray(dest)) {
+      proms.push(...dest.map(dest => getDestination(pdfDocProxy, dest)));
+    } else if (typeof dest === 'string') {
+      proms.push(getDestination(pdfDocProxy, dest));
+    }
+  }
+
+  // Collect results all at once, so we don't have to pay for the cost of
+  // queueing messages sent to the worker
+  const results = await Promise.all(proms);
+
+  // Split results into pages
+  const map = new Map<number, OutlinePosition[]>();
+  for (const result of results) {
+    if (!result) {
+      continue; // Filter out null
+    }
+    const { pageNumber } = result;
+    if (!map.has(pageNumber)) {
+      map.set(pageNumber, []);
+    }
+    map.get(pageNumber)?.push(result);
+  }
+
+  // Freeze objects so consumers cannot mutate
+  for (const pagePos of map.values()) {
+    for (const pos of pagePos) {
+      Object.freeze(pos);
+    }
+    Object.freeze(pagePos);
+  }
+  Object.freeze(map);
+
+  return map;
+}
+
+async function getDestination(
+  pdfDocProxy: pdfjs.PDFDocumentProxy,
+  dest: string
+): Promise<Nullable<OutlinePosition>> {
+  const result = await pdfDocProxy.getDestination(dest);
+  if (!result) {
+    return null;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [ref, _format, leftPoint, bottomPoint] = result;
+  const pageIndex = await pdfDocProxy.getPageIndex(ref);
+  const pageNumber = pageIndex + 1;
+  return { pageNumber, dest, leftPoint, bottomPoint };
 }

--- a/ui/library/src/context/DocumentContext.ts
+++ b/ui/library/src/context/DocumentContext.ts
@@ -2,40 +2,23 @@ import * as React from 'react';
 import { pdfjs } from 'react-pdf';
 
 import { Dimensions } from '../components/types/boundingBox';
-import { OutlineNode } from '../components/types/outline';
+import {
+  OutlineNode,
+  OutlinePosition,
+  OutlinePositionsByPageNumberMap,
+  OutlineTarget,
+  OutlineTargetArgs,
+} from '../components/types/outline';
 import { Nullable } from '../components/types/utils';
 import { logProviderWarning } from '../utils/provider';
-import { PageRotation } from '../utils/rotate';
 import { calculateTargetPosition } from '../utils/scroll';
-
-export type OutlinePosition = {
-  pageNumber: number;
-  dest: string;
-  leftPoint: number;
-  bottomPoint: number;
-};
-
-export type OutlinePositionsByPageNumberMap = Map<number, OutlinePosition[]>;
-
-export type OutlineTarget = {
-  dest: string;
-  leftPx: number;
-  topPx: number;
-};
-
 export interface IDocumentContext {
   numPages: number;
   outline: Nullable<Array<OutlineNode>>;
   outlinePositions: Nullable<OutlinePositionsByPageNumberMap>;
   pageDimensions: Dimensions; // Scaled at 100%
   pdfDocProxy?: pdfjs.PDFDocumentProxy;
-  getOutlineTargets: (opts: {
-    pageNumber?: number;
-    pageIndex?: number;
-    scale: number;
-    rotation: PageRotation;
-    pageDimensions: Dimensions;
-  }) => OutlineTarget[];
+  getOutlineTargets: (opts: OutlineTargetArgs) => OutlineTarget[];
   setNumPages: (numPages: number) => void;
   setOutline: (outline: Nullable<Array<OutlineNode>>) => void;
   setOutlinePositions: (outlinePositions: Nullable<OutlinePositionsByPageNumberMap>) => void;
@@ -85,13 +68,7 @@ export function useDocumentContextProps(): IDocumentContext {
       scale,
       rotation,
       pageDimensions,
-    }: {
-      pageNumber?: number;
-      pageIndex?: number;
-      scale: number;
-      rotation: PageRotation;
-      pageDimensions: Dimensions;
-    }): OutlineTarget[] => {
+    }: OutlineTargetArgs): OutlineTarget[] => {
       if (typeof pageIndex === 'number') {
         pageNumber = pageIndex + 1;
       }

--- a/ui/library/src/context/DocumentContext.ts
+++ b/ui/library/src/context/DocumentContext.ts
@@ -61,6 +61,7 @@ export function useDocumentContextProps(): IDocumentContext {
   const [pageDimensions, setPageDimensions] = React.useState<Dimensions>({ height: 0, width: 0 });
   const [pdfDocProxy, setPdfDocProxy] = React.useState<pdfjs.PDFDocumentProxy>();
 
+  // Draw outline target into the pdf based on the args
   const getOutlineTargets = React.useCallback(
     ({
       pageNumber,

--- a/ui/library/src/context/ScrollContext.ts
+++ b/ui/library/src/context/ScrollContext.ts
@@ -32,7 +32,6 @@ export interface IScrollContext {
   resetScrollObservers: () => void;
   setScrollRoot: (root: Nullable<Element>) => any;
   scrollToOutlineTarget: (dest: NodeDestination) => void;
-  scrollToPage: (pageNumber: PageNumber) => void;
   setScrollThreshold: (scrollThreshold: Nullable<number>) => any;
   scrollThresholdReachedInDirection: Nullable<ScrollDirection>;
   isAtTop: Nullable<boolean>;
@@ -219,7 +218,6 @@ export function useScrollContextProps(): IScrollContext {
     resetScrollObservers,
     setScrollRoot,
     scrollToOutlineTarget,
-    scrollToPage,
     setScrollThreshold,
     scrollThresholdReachedInDirection,
     isAtTop,

--- a/ui/library/src/context/ScrollContext.ts
+++ b/ui/library/src/context/ScrollContext.ts
@@ -28,8 +28,8 @@ export interface IScrollContext {
   isOutlineTargetVisible: (dest: NodeDestination) => boolean;
   isPageVisible: (pageNumber: PageNumber) => boolean;
   scrollDirection: Nullable<ScrollDirection>;
-  visibleOutlineTargets: Map<NodeDestination, number>;
-  visiblePageNumbers: Map<number, number>;
+  visibleOutlineTargets: Map<NodeDestination, number>; // mapping node destination with their intersection ratio
+  visiblePageNumbers: Map<number, number>; // mapping page number with their intersection ratio
   resetScrollObservers: () => void;
   setScrollRoot: (root: Nullable<Element>) => any;
   scrollToOutlineTarget: (dest: NodeDestination) => void;
@@ -183,6 +183,9 @@ export function useScrollContextProps(): IScrollContext {
       root: root,
       setVisibleEntries: setVisibleOutlineNodes,
       onVisibleEntriesChange: ({ visibleEntries, hiddenEntries, lastEntries }) => {
+        // we will always want to assign new entries with last entries which is the last visible one
+        // then we will remove the element not in viewport from hiddenEntries and add new entries based
+        // on new visibleEntries
         const newEntries = new Map(lastEntries);
         for (const el of hiddenEntries) {
           const dest = el.target.getAttribute(OUTLINE_ATTRIBUTE);

--- a/ui/library/src/utils/VisibleEntriesDetector.ts
+++ b/ui/library/src/utils/VisibleEntriesDetector.ts
@@ -1,17 +1,17 @@
 const DEFAULT_ROOT_MARGIN = '50px';
 const DEFAULT_THRESHOLD = 0.00001;
 
-export type SetVisibleEntriesCallback<TEntry> = (visible: Set<TEntry>) => void;
+export type SetVisibleEntriesCallback<TEntry> = (visible: Map<TEntry, number>) => void;
 export type onVisibleEntriesChangeCallback<TEntry> = (args: {
   visibleEntries: IntersectionObserverEntry[];
   hiddenEntries: IntersectionObserverEntry[];
-  lastEntries: Set<TEntry>;
-}) => Set<TEntry>;
+  lastEntries: Map<TEntry, number>;
+}) => Map<TEntry, number>;
 
-export default class VisibleEntriesDetector<TEntry> {
+export default class VisibilityEntriesDetector<TEntry> {
   _root: Element;
   _observer: IntersectionObserver;
-  _lastVisibleEntries: Set<TEntry>;
+  _lastVisibleEntries: Map<TEntry, number>;
   _setVisibleEntries: SetVisibleEntriesCallback<TEntry>;
   _onVisibleEntriesChange: onVisibleEntriesChangeCallback<TEntry>;
 
@@ -25,7 +25,7 @@ export default class VisibleEntriesDetector<TEntry> {
     onVisibleEntriesChange: onVisibleEntriesChangeCallback<TEntry>;
   }) {
     this._root = root;
-    this._lastVisibleEntries = new Set();
+    this._lastVisibleEntries = new Map();
     this._setVisibleEntries = setVisibleEntries;
     this._onVisibleEntriesChange = onVisibleEntriesChange;
     this._observer = new IntersectionObserver(
@@ -34,14 +34,22 @@ export default class VisibleEntriesDetector<TEntry> {
         const visibleEntries = entries.filter(entry => entry.isIntersecting);
         const hiddenEntries = entries.filter(entry => !entry.isIntersecting);
 
+        // this to get the highest value for max intersection ratio but if there is no element in the
+        // visibleEntries then we need second param to be 0 so we dont have negative infinity
+        const maxRatio = Math.max(...visibleEntries.map(entry => entry.intersectionRatio), 0);
+
+        const actualVisibleEntry = visibleEntries.filter(
+          entry => entry.intersectionRatio === maxRatio
+        );
+
         // Determine what needs saved
         const newVisibleEntries = this._onVisibleEntriesChange({
-          visibleEntries,
+          visibleEntries: actualVisibleEntry,
           hiddenEntries,
           lastEntries: this._lastVisibleEntries,
         });
 
-        const frozenEntries = new Set(newVisibleEntries);
+        const frozenEntries = new Map(newVisibleEntries);
         Object.freeze(frozenEntries);
         this._lastVisibleEntries = frozenEntries;
         this._setVisibleEntries(frozenEntries);

--- a/ui/library/src/utils/VisibleEntriesDetector.ts
+++ b/ui/library/src/utils/VisibleEntriesDetector.ts
@@ -8,7 +8,7 @@ export type onVisibleEntriesChangeCallback<TEntry> = (args: {
   lastEntries: Map<TEntry, number>;
 }) => Map<TEntry, number>;
 
-export default class VisibilityEntriesDetector<TEntry> {
+export default class VisibleEntriesDetector<TEntry> {
   _root: Element;
   _observer: IntersectionObserver;
   _lastVisibleEntries: Map<TEntry, number>;
@@ -17,10 +17,12 @@ export default class VisibilityEntriesDetector<TEntry> {
 
   constructor({
     root,
+    thresHold,
     setVisibleEntries,
     onVisibleEntriesChange,
   }: {
     root: Element;
+    thresHold?: number | Array<number>;
     setVisibleEntries: SetVisibleEntriesCallback<TEntry>;
     onVisibleEntriesChange: onVisibleEntriesChangeCallback<TEntry>;
   }) {
@@ -34,17 +36,9 @@ export default class VisibilityEntriesDetector<TEntry> {
         const visibleEntries = entries.filter(entry => entry.isIntersecting);
         const hiddenEntries = entries.filter(entry => !entry.isIntersecting);
 
-        // this to get the highest value for max intersection ratio but if there is no element in the
-        // visibleEntries then we need second param to be 0 so we dont have negative infinity
-        const maxRatio = Math.max(...visibleEntries.map(entry => entry.intersectionRatio), 0);
-
-        const actualVisibleEntry = visibleEntries.filter(
-          entry => entry.intersectionRatio === maxRatio
-        );
-
         // Determine what needs saved
         const newVisibleEntries = this._onVisibleEntriesChange({
-          visibleEntries: actualVisibleEntry,
+          visibleEntries,
           hiddenEntries,
           lastEntries: this._lastVisibleEntries,
         });
@@ -57,9 +51,9 @@ export default class VisibilityEntriesDetector<TEntry> {
 
       // Default setting for intersection observer
       {
-        root: this._root,
+        root: this._root.tagName?.toLowerCase() === 'html' ? null : this._root,
         rootMargin: DEFAULT_ROOT_MARGIN,
-        threshold: DEFAULT_THRESHOLD,
+        threshold: thresHold ? thresHold : DEFAULT_THRESHOLD,
       }
     );
   }

--- a/ui/library/src/utils/scroll.ts
+++ b/ui/library/src/utils/scroll.ts
@@ -172,16 +172,16 @@ export function getPagePropertiesInPixels(): PageProperties {
 
 export function calculateTargetPosition({
   scale,
-  rotation = PageRotation.Rotate0,
   leftPoint,
   bottomPoint,
   pageDimensions,
+  rotation = PageRotation.Rotate0,
 }: {
   scale: number;
-  rotation: PageRotation;
   leftPoint: number;
   bottomPoint: number;
   pageDimensions: Dimensions;
+  rotation: PageRotation;
 }): { leftPx: number; topPx: number } {
   switch (rotation) {
     default:

--- a/ui/library/src/utils/scroll.ts
+++ b/ui/library/src/utils/scroll.ts
@@ -1,3 +1,4 @@
+import { Dimensions } from '../components/types/boundingBox';
 import { PageProperties } from '../components/types/page';
 import { Nullable } from '../components/types/utils';
 import { PageRotation } from '../utils/rotate';
@@ -167,4 +168,27 @@ export function getPagePropertiesInPixels(): PageProperties {
   };
 
   return pageProperties;
+}
+
+export function calculateTargetPosition({
+  scale,
+  rotation = PageRotation.Rotate0,
+  leftPoint,
+  bottomPoint,
+  pageDimensions,
+}: {
+  scale: number;
+  rotation: PageRotation;
+  leftPoint: number;
+  bottomPoint: number;
+  pageDimensions: Dimensions;
+}): { leftPx: number; topPx: number } {
+  switch (rotation) {
+    default:
+    case PageRotation.Rotate0: {
+      const leftPx = (leftPoint / PDF_WIDTH_POINTS) * pageDimensions.width * scale;
+      const topPx = (1 - bottomPoint / PDF_HEIGHT_POINTS) * pageDimensions.height * scale;
+      return { leftPx, topPx };
+    }
+  }
 }

--- a/ui/library/test/context/ScrollContext.test.tsx
+++ b/ui/library/test/context/ScrollContext.test.tsx
@@ -6,6 +6,7 @@ import { Nullable } from '../../../library/src/components/types/utils';
 import { NodeDestination } from '../../src/components/types/outline';
 import {
   IScrollContext,
+  PageNumber,
   ScrollContext,
   useScrollContextProps,
 } from '../../src/context/ScrollContext';
@@ -28,9 +29,9 @@ describe('<ScrollContext/>', () => {
   let _setScrollRoot: (root: Nullable<Element>) => any;
   let _resetScrollObservers: () => any;
   let _isOutlineTargetVisible: (dest: NodeDestination) => boolean;
-  let _isPageVisible: (opts: { pageNumber?: number; pageIndex?: number }) => boolean;
-  let _scrollToPage: (opts: { pageNumber?: number; pageIndex?: number }) => void;
-  let _getVisibleElement: (visibleElements: Map<any, number>) => any;
+  let _isPageVisible: (opts: PageNumber) => boolean;
+  let _scrollToPage: (opts: PageNumber) => void;
+  let _getMaxVisibleElement: (visibleElements: Map<any, number>) => any;
 
   beforeEach(() => {
     (global as any).IntersectionObserver = function (...args) {
@@ -54,7 +55,7 @@ describe('<ScrollContext/>', () => {
                 isOutlineTargetVisible,
                 isPageVisible,
                 scrollToPage,
-                getVisibleElement,
+                getMaxVisibleElement,
               } = args;
               // eslint-disable-next-line @typescript-eslint/no-unused-vars
               _setScrollRoot = setScrollRoot;
@@ -67,7 +68,7 @@ describe('<ScrollContext/>', () => {
               // eslint-disable-next-line @typescript-eslint/no-unused-vars
               _scrollToPage = scrollToPage;
               // eslint-disable-next-line @typescript-eslint/no-unused-vars
-              _getVisibleElement = getVisibleElement;
+              _getMaxVisibleElement = getMaxVisibleElement;
               return (
                 <div>
                   <div className="scrollDirection">{scrollDirection}</div>

--- a/ui/library/test/context/ScrollContext.test.tsx
+++ b/ui/library/test/context/ScrollContext.test.tsx
@@ -29,6 +29,8 @@ describe('<ScrollContext/>', () => {
   let _resetScrollObservers: () => any;
   let _isOutlineTargetVisible: (dest: NodeDestination) => boolean;
   let _isPageVisible: (opts: { pageNumber?: number; pageIndex?: number }) => boolean;
+  let _scrollToPage: (opts: { pageNumber?: number; pageIndex?: number }) => void;
+  let _getVisibleElement: (visibleElements: Map<any, number>) => any;
 
   beforeEach(() => {
     (global as any).IntersectionObserver = function (...args) {
@@ -45,10 +47,14 @@ describe('<ScrollContext/>', () => {
                 scrollDirection,
                 visibleOutlineTargets,
                 visiblePageNumbers,
+                scrollThresholdReachedInDirection,
+                isAtTop,
                 setScrollRoot,
                 resetScrollObservers,
                 isOutlineTargetVisible,
                 isPageVisible,
+                scrollToPage,
+                getVisibleElement,
               } = args;
               // eslint-disable-next-line @typescript-eslint/no-unused-vars
               _setScrollRoot = setScrollRoot;
@@ -58,11 +64,19 @@ describe('<ScrollContext/>', () => {
               _isOutlineTargetVisible = isOutlineTargetVisible;
               // eslint-disable-next-line @typescript-eslint/no-unused-vars
               _isPageVisible = isPageVisible;
+              // eslint-disable-next-line @typescript-eslint/no-unused-vars
+              _scrollToPage = scrollToPage;
+              // eslint-disable-next-line @typescript-eslint/no-unused-vars
+              _getVisibleElement = getVisibleElement;
               return (
                 <div>
                   <div className="scrollDirection">{scrollDirection}</div>
                   <div className="visibleOutlineTargets">{visibleOutlineTargets}</div>
                   <div className="visiblePageNumbers">{visiblePageNumbers}</div>
+                  <div className="scrollThresholdReachedInDirection">
+                    {scrollThresholdReachedInDirection}
+                  </div>
+                  <div className="isAtTop">{isAtTop}</div>
                 </div>
               );
             }}
@@ -87,5 +101,13 @@ describe('<ScrollContext/>', () => {
 
   it('provides a default visible page numbers', () => {
     expectTextFromClassName('visiblePageNumbers', '');
+  });
+
+  it('provides a default scrollThresholdReachedInDirection', () => {
+    expectTextFromClassName('scrollThresholdReachedInDirection', '');
+  });
+
+  it('provides a default isAtTop', () => {
+    expectTextFromClassName('isAtTop', '');
   });
 });

--- a/ui/library/test/context/ScrollContext.test.tsx
+++ b/ui/library/test/context/ScrollContext.test.tsx
@@ -27,7 +27,6 @@ describe('<ScrollContext/>', () => {
 
   let _setScrollRoot: (root: Nullable<Element>) => any;
   let _resetScrollObservers: () => any;
-  let _scrollToPage: (opts: { pageNumber?: number; pageIndex?: number }) => void;
   let _isOutlineTargetVisible: (dest: NodeDestination) => boolean;
   let _isPageVisible: (opts: { pageNumber?: number; pageIndex?: number }) => boolean;
 
@@ -48,7 +47,6 @@ describe('<ScrollContext/>', () => {
                 visiblePageNumbers,
                 setScrollRoot,
                 resetScrollObservers,
-                scrollToPage,
                 isOutlineTargetVisible,
                 isPageVisible,
               } = args;
@@ -56,8 +54,6 @@ describe('<ScrollContext/>', () => {
               _setScrollRoot = setScrollRoot;
               // eslint-disable-next-line @typescript-eslint/no-unused-vars
               _resetScrollObservers = resetScrollObservers;
-              // eslint-disable-next-line @typescript-eslint/no-unused-vars
-              _scrollToPage = scrollToPage;
               // eslint-disable-next-line @typescript-eslint/no-unused-vars
               _isOutlineTargetVisible = isOutlineTargetVisible;
               // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/ui/library/test/utils/VisibleEntriesDetector.test.ts
+++ b/ui/library/test/utils/VisibleEntriesDetector.test.ts
@@ -21,7 +21,10 @@ describe('VisibilityDetector', () => {
   });
 
   it('should pass the value return when calling OnVisibilityChange to setEntries', () => {
-    const expectedEntries = new Set([1, 2, 3]);
+    const expectedEntries = new Map();
+    expectedEntries.set(1, 0.00123);
+    expectedEntries.set(2, 0.012567);
+    expectedEntries.set(3, 0.2);
     const mockRoot = {};
     const mockSetVisibleEntries = sandbox.mock();
     const mockOnVisibilityChange = sandbox.mock().returns(expectedEntries);
@@ -39,7 +42,10 @@ describe('VisibilityDetector', () => {
   });
 
   it('should receive correct visibleEntries, hiddenEntries when calling OnVisibilityChange', () => {
-    const expectedEntries = new Set([1, 2, 3]);
+    const expectedEntries = new Map();
+    expectedEntries.set(1, 0.00123);
+    expectedEntries.set(2, 0.012567);
+    expectedEntries.set(3, 0.2);
     const mockRoot = {};
     const mockSetVisibleEntries = sandbox.mock();
     const mockOnVisibilityChange = sandbox.mock().returns(expectedEntries);
@@ -52,10 +58,10 @@ describe('VisibilityDetector', () => {
     });
 
     const mockEntries = [
-      { isIntersecting: false, target: 'hidden.1' },
-      { isIntersecting: true, target: 'visible.2' },
-      { isIntersecting: true, target: 'visible.3' },
-      { isIntersecting: false, target: 'hidden.4' },
+      { isIntersecting: false, target: 'hidden.1', intersectionRatio: 0.002345 },
+      { isIntersecting: true, target: 'visible.2', intersectionRatio: 0.0543 },
+      { isIntersecting: true, target: 'visible.3', intersectionRatio: 0.123456 },
+      { isIntersecting: false, target: 'hidden.4', intersectionRatio: 0.000456 },
     ];
     mockObserver.__onChange(mockEntries);
 
@@ -63,13 +69,16 @@ describe('VisibilityDetector', () => {
     const visibleEntries = args?.visibleEntries.map(entry => entry.target);
     const hidddenEntries = args?.hiddenEntries.map(entry => entry.target);
 
-    expect(Array.from(visibleEntries)).to.deep.equal(['visible.2', 'visible.3']);
+    expect(Array.from(visibleEntries)).to.deep.equal(['visible.3']);
     expect(Array.from(hidddenEntries)).to.deep.equal(['hidden.1', 'hidden.4']);
     expect(Array.from(args?.lastEntries)).to.deep.equal([]);
   });
 
   it('should pass the last return of visibility change as last entry', () => {
-    const expectedEntries = new Set([1, 2, 3]);
+    const expectedEntries = new Map();
+    expectedEntries.set(1, 0.00123);
+    expectedEntries.set(2, 0.012567);
+    expectedEntries.set(3, 0.2);
     const mockRoot = {};
     const mockSetVisibleEntries = sandbox.mock();
     const mockOnVisibilityChange = sandbox.mock().returns(expectedEntries);
@@ -87,7 +96,10 @@ describe('VisibilityDetector', () => {
   });
 
   it('should find node to observe based on the pass selector', () => {
-    const expectedEntries = new Set([1, 2, 3]);
+    const expectedEntries = new Map();
+    expectedEntries.set(1, 0.00123);
+    expectedEntries.set(2, 0.012567);
+    expectedEntries.set(3, 0.2);
     const mockRoot = {
       querySelectorAll: () => ['.test', '.test1'],
     };
@@ -110,7 +122,10 @@ describe('VisibilityDetector', () => {
   });
 
   it('should disconnect the observe', () => {
-    const expectedEntries = new Set([1, 2, 3]);
+    const expectedEntries = new Map();
+    expectedEntries.set(1, 0.00123);
+    expectedEntries.set(2, 0.012567);
+    expectedEntries.set(3, 0.2);
     const mockRoot = {
       querySelectorAll: () => Array.from(['.test', '.test1']),
     };

--- a/ui/library/test/utils/VisibleEntriesDetector.test.ts
+++ b/ui/library/test/utils/VisibleEntriesDetector.test.ts
@@ -69,7 +69,7 @@ describe('VisibilityDetector', () => {
     const visibleEntries = args?.visibleEntries.map(entry => entry.target);
     const hidddenEntries = args?.hiddenEntries.map(entry => entry.target);
 
-    expect(Array.from(visibleEntries)).to.deep.equal(['visible.3']);
+    expect(Array.from(visibleEntries)).to.deep.equal(['visible.2', 'visible.3']);
     expect(Array.from(hidddenEntries)).to.deep.equal(['hidden.1', 'hidden.4']);
     expect(Array.from(args?.lastEntries)).to.deep.equal([]);
   });


### PR DESCRIPTION
## Description
Ref: https://github.com/allenai/scholar/issues/32907
After adding scroll direction its time to add ability to detecting current page & outline to ScrollContext  

## Reviewer Instructions

With Paul's original code it will give us multiple pages if we are between two pages. So one way to tackle this is we need to convert from a Set() to Map(). Thanks to IntersectionObserverEntry it will provide us the intersectionRatio to see which one is closer to the viewport. 

## Testing Plan

Add console.log in ScrollContext toward end to see the value of VisiblePages & VisbleOutlineTarget. Changing unit test format to fit with Map() value and verify no unit test fail.

## Output / Screenshots

https://user-images.githubusercontent.com/84343285/180864127-21c3b502-a2aa-477e-8597-8279c6a51f73.mov



### A11y

No A11y involvement 