### PR TITLE
Adding missing data-attribute in PDF Component

### DIFF
--- a/ui/library/src/components/PageWrapper.tsx
+++ b/ui/library/src/components/PageWrapper.tsx
@@ -59,6 +59,7 @@ export const PageWrapper: React.FunctionComponent<Props> = ({
     <div
       id={generatePageIdFromIndex(pageIndex)}
       className="reader__page"
+      data-page-number={pageIndex + 1}
       style={getPageStyle()}
       {...extraProps}>
       {children}


### PR DESCRIPTION
## Description
Ref: https://github.com/allenai/scholar/issues/32907

When i was testing why outline was not at the right position in Pagwrapper i ended up removing the data-page-number attribute so it makes it not working for visiblePageNumbers. This PR added back that attribute

## Reviewer Instructions

Added back the missing attribute. 

## Testing Plan

Verify through console.log that thing works

## Output / Screenshots


### Before


https://user-images.githubusercontent.com/84343285/181598510-1ecb4709-be4f-4fab-885b-9472009416d9.mov


### After

https://user-images.githubusercontent.com/84343285/181598149-2034ee9d-f447-4809-8f7c-78c7ed00a157.mov



### A11y

No A11y involvement 