### PR TITLE
Add tracking page number in PDF Component library

### DIFF
--- a/ui/demo/components/Header.tsx
+++ b/ui/demo/components/Header.tsx
@@ -1,5 +1,6 @@
 import {
   DownloadButton,
+  PageNumberControl,
   rotateClockwise,
   rotateCounterClockwise,
   scrollToId,
@@ -72,6 +73,9 @@ export const Header: React.FunctionComponent<Props> = ({ pdfUrl }: Props) => {
 
   return (
     <div className="reader__header">
+      <div className="header-control">
+        <PageNumberControl />
+      </div>
       <div className="header-control">
         <SimpleZoomControl />
       </div>

--- a/ui/library/index.ts
+++ b/ui/library/index.ts
@@ -14,6 +14,7 @@ import {
 import { Outline } from './src/components/outline/Outline';
 import { OutlineItem } from './src/components/outline/OutlineItem';
 import { Overlay, Props as OverlayProps } from './src/components/Overlay';
+import { PageNumberControl } from './src/components/PageNumberControl';
 import { PageProps, PageWrapper, Props as PageWrapperProps } from './src/components/PageWrapper';
 import {
   BoundingBox as BoundingBoxType,
@@ -89,6 +90,7 @@ export {
   Outline,
   OutlineItem,
   Overlay,
+  PageNumberControl,
   PageWrapper,
   rotateClockwise,
   rotateCounterClockwise,
@@ -118,6 +120,7 @@ export default {
   Outline,
   OutlineItem,
   Overlay,
+  PageNumberControl,
   PageRotation,
   PageWrapper,
   rotateClockwise,

--- a/ui/library/less/styles.less
+++ b/ui/library/less/styles.less
@@ -78,7 +78,7 @@
   display: flex;
 }
 
-.reader__page-number-control__current-page {
+.reader__page-number-control__current-page[type="number"]  {
   border-radius: 3px;
   height: 24px;
   -moz-appearance: textfield;

--- a/ui/library/less/styles.less
+++ b/ui/library/less/styles.less
@@ -77,3 +77,24 @@
   align-items: center;
   display: flex;
 }
+
+.reader__page-number-control__current-page {
+  border-radius: 3px;
+  height: 24px;
+  -moz-appearance: textfield;
+  text-align: center;
+  width: 24px;
+}
+
+.reader__page-number-control__total-pages {
+  border: none;
+}
+
+.reader__page-number-control__separator {
+  padding: 5px;
+}
+
+.reader__page-number-control__current-page::-webkit-inner-spin-button,
+.reader__page-number-control__current-page::-webkit-outer-spin-button { 
+	-webkit-appearance: none;
+}

--- a/ui/library/src/components/PageNumberControl.tsx
+++ b/ui/library/src/components/PageNumberControl.tsx
@@ -6,7 +6,6 @@ import { ScrollContext } from '../context/ScrollContext';
 import { getMaxVisibleElement } from '../utils/MaxVisibleElement';
 
 export type Props = {
-  showDivider?: boolean;
   className?: string;
 };
 
@@ -14,15 +13,12 @@ type TODO__TIMER = any;
 
 const DELAY_SCROLL_TIME_OUT_MS = 1000;
 
-export const PageNumberControl: React.FunctionComponent<Props> = ({
-  showDivider,
-  className,
-}: Props) => {
+export const PageNumberControl: React.FunctionComponent<Props> = ({ className }: Props) => {
   const delayTimerRef = React.useRef<TODO__TIMER>();
   const { numPages } = React.useContext(DocumentContext);
   const { scrollToPage, visiblePageRatios } = React.useContext(ScrollContext);
-  const [minPage, setMinPage] = React.useState(0);
-  const [userInput, setUserInput] = React.useState('0');
+  const [minPage, setMinPage] = React.useState<number>(0);
+  const [userInput, setUserInput] = React.useState<string>('0');
 
   // Initialize page control element
   React.useEffect(() => {
@@ -31,6 +27,9 @@ export const PageNumberControl: React.FunctionComponent<Props> = ({
     }
   }, [numPages]);
 
+  // Everytime we scroll through the page this useEffect
+  // will trigger and set current page based on our current
+  // scroll position
   React.useEffect(() => {
     if (visiblePageRatios.size !== 0) {
       const maxVisiblePageNumber = getMaxVisibleElement(visiblePageRatios);
@@ -53,6 +52,9 @@ export const PageNumberControl: React.FunctionComponent<Props> = ({
         clearTimeout(delayTimerRef.current);
       }
 
+      // After user input the page that they want to scroll to
+      // our ref will start setting a delay around 1s before scroll
+      // to the position that user desire
       const newPageNumber = parseInt(value, 10);
       if (newPageNumber >= minPage && newPageNumber <= numPages) {
         delayTimerRef.current = setTimeout(() => {
@@ -85,18 +87,10 @@ export const PageNumberControl: React.FunctionComponent<Props> = ({
         onChange={onPageNumberChange}
         onBlur={handleBlur}
       />
-      {showDivider && <span className="reader__page-number-control__separator">/</span>}
-      <input
-        aria-label="Total Pages"
-        className="reader__page-number-control__total-pages"
-        type="number"
-        value={numPages}
-        disabled={true}
-      />
+      <span className="reader__page-number-control__separator">/</span>
+      <span aria-label="Total Pages" className="reader__page-number-control__total-pages">
+        {numPages}
+      </span>
     </div>
   );
-};
-
-PageNumberControl.defaultProps = {
-  showDivider: true,
 };

--- a/ui/library/src/components/PageNumberControl.tsx
+++ b/ui/library/src/components/PageNumberControl.tsx
@@ -1,0 +1,102 @@
+import classnames from 'classnames';
+import * as React from 'react';
+
+import { DocumentContext } from '../context/DocumentContext';
+import { ScrollContext } from '../context/ScrollContext';
+import { getMaxVisibleElement } from '../utils/MaxVisibleElement';
+
+export type Props = {
+  showDivider?: boolean;
+  className?: string;
+};
+
+type TODO__TIMER = any;
+
+const DELAY_SCROLL_TIME_OUT_MS = 1000;
+
+export const PageNumberControl: React.FunctionComponent<Props> = ({
+  showDivider,
+  className,
+}: Props) => {
+  const delayTimerRef = React.useRef<TODO__TIMER>();
+  const { numPages } = React.useContext(DocumentContext);
+  const { scrollToPage, visiblePageRatios } = React.useContext(ScrollContext);
+  const [minPage, setMinPage] = React.useState(0);
+  const [userInput, setUserInput] = React.useState('0');
+
+  // Initialize page control element
+  React.useEffect(() => {
+    if (numPages != 0) {
+      setMinPage(1);
+    }
+  }, [numPages]);
+
+  React.useEffect(() => {
+    if (visiblePageRatios.size !== 0) {
+      const maxVisiblePageNumber = getMaxVisibleElement(visiblePageRatios);
+      if (maxVisiblePageNumber) {
+        setUserInput(maxVisiblePageNumber.toString());
+      }
+    }
+  }, [visiblePageRatios]);
+
+  const onPageNumberChange = React.useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const { value } = event.currentTarget;
+      // Decimal case
+      if (!Number.isInteger(value)) {
+        setUserInput(parseInt(value, 10).toString());
+      }
+
+      setUserInput(value);
+      if (delayTimerRef.current) {
+        clearTimeout(delayTimerRef.current);
+      }
+
+      const newPageNumber = parseInt(value, 10);
+      if (newPageNumber >= minPage && newPageNumber <= numPages) {
+        delayTimerRef.current = setTimeout(() => {
+          scrollToPage({ pageNumber: newPageNumber });
+        }, DELAY_SCROLL_TIME_OUT_MS);
+      }
+    },
+    [minPage, numPages, scrollToPage]
+  );
+
+  const handleBlur = React.useCallback(() => {
+    if (delayTimerRef.current) {
+      clearTimeout(delayTimerRef.current);
+    }
+    const pageNumber = parseInt(userInput, 10);
+    if (Number.isNaN(pageNumber)) {
+      return;
+    }
+    scrollToPage({ pageNumber });
+  }, [userInput]);
+
+  return (
+    <div className={classnames('reader__page-number-control', className)}>
+      <input
+        aria-label="Current Page"
+        className="reader__page-number-control__current-page"
+        type="number"
+        name="currentPage"
+        value={userInput}
+        onChange={onPageNumberChange}
+        onBlur={handleBlur}
+      />
+      {showDivider && <span className="reader__page-number-control__separator">/</span>}
+      <input
+        aria-label="Total Pages"
+        className="reader__page-number-control__total-pages"
+        type="number"
+        value={numPages}
+        disabled={true}
+      />
+    </div>
+  );
+};
+
+PageNumberControl.defaultProps = {
+  showDivider: true,
+};

--- a/ui/library/src/context/ScrollContext.ts
+++ b/ui/library/src/context/ScrollContext.ts
@@ -35,7 +35,6 @@ export interface IScrollContext {
   scrollToOutlineTarget: (dest: NodeDestination) => void;
   setScrollThreshold: (scrollThreshold: Nullable<number>) => void;
   scrollToPage: (pageNumber: PageNumber) => void;
-  getMaxVisibleElement: (visibleElements: Map<any, number>) => any;
   scrollThresholdReachedInDirection: Nullable<ScrollDirection>;
   isAtTop: Nullable<boolean>;
 }
@@ -66,9 +65,6 @@ const DEFAULT_CONTEXT: IScrollContext = {
   },
   scrollToPage: opts => {
     logProviderWarning(`scrollToPage(${JSON.stringify(opts)})`, 'ScrollContext');
-  },
-  getMaxVisibleElement: opts => {
-    logProviderWarning(`getVisibleElement(${JSON.stringify(opts)})`, 'ScrollContext');
   },
   scrollThresholdReachedInDirection: null,
   isAtTop: null,
@@ -171,18 +167,6 @@ export function useScrollContextProps(): IScrollContext {
       ?.scrollIntoView({ behavior: 'smooth' });
   }, []);
 
-  const getMaxVisibleElement = (visibleElements: Map<any, number>): any => {
-    let maxPageNum = null;
-    let maxRatio = 0;
-    for (const [pageNum, ratio] of visibleElements) {
-      if (maxRatio < ratio) {
-        maxPageNum = pageNum;
-        maxRatio = ratio;
-      }
-    }
-    return maxPageNum;
-  };
-
   // Watch outline nodes
   React.useEffect(() => {
     const root = scrollRoot || document.documentElement;
@@ -243,7 +227,6 @@ export function useScrollContextProps(): IScrollContext {
     scrollToOutlineTarget,
     setScrollThreshold,
     scrollToPage,
-    getMaxVisibleElement,
     scrollThresholdReachedInDirection,
     isAtTop,
   };

--- a/ui/library/src/context/ScrollContext.ts
+++ b/ui/library/src/context/ScrollContext.ts
@@ -29,11 +29,11 @@ export interface IScrollContext {
   isPageVisible: (pageNumber: PageNumber) => boolean;
   scrollDirection: Nullable<ScrollDirection>;
   visibleOutlineTargets: Map<NodeDestination, number>; // mapping node destination with their intersection ratio
-  visiblePageNumbers: Map<number, number>; // mapping page number with their intersection ratio
+  visiblePageRatios: Map<number, number>; // mapping page number with their intersection ratio
   resetScrollObservers: () => void;
-  setScrollRoot: (root: Nullable<Element>) => any;
+  setScrollRoot: (root: Nullable<Element>) => void;
   scrollToOutlineTarget: (dest: NodeDestination) => void;
-  setScrollThreshold: (scrollThreshold: Nullable<number>) => any;
+  setScrollThreshold: (scrollThreshold: Nullable<number>) => void;
   scrollToPage: (pageNumber: PageNumber) => void;
   getMaxVisibleElement: (visibleElements: Map<any, number>) => any;
   scrollThresholdReachedInDirection: Nullable<ScrollDirection>;
@@ -43,7 +43,7 @@ export interface IScrollContext {
 const DEFAULT_CONTEXT: IScrollContext = {
   scrollDirection: null,
   visibleOutlineTargets: new Map(),
-  visiblePageNumbers: new Map(),
+  visiblePageRatios: new Map(),
   isOutlineTargetVisible: opts => {
     logProviderWarning(`isOutlineTargetVisible(${JSON.stringify(opts)})`, 'ScrollContext');
     return false;
@@ -127,7 +127,7 @@ export function useScrollContextProps(): IScrollContext {
     return map;
   });
 
-  const [visiblePageNumbers, setVisiblePageNumbers] = React.useState<Map<number, number>>(() => {
+  const [visiblePageRatios, setVisiblePageRatios] = React.useState<Map<number, number>>(() => {
     const map = new Map<number, number>();
     Object.freeze(map);
     return map;
@@ -154,9 +154,9 @@ export function useScrollContextProps(): IScrollContext {
       if (typeof pageNumber !== 'number') {
         return false;
       }
-      return visiblePageNumbers.has(pageNumber);
+      return visiblePageRatios.has(pageNumber);
     },
-    [visiblePageNumbers]
+    [visiblePageRatios]
   );
 
   const scrollToPage = React.useCallback(({ pageNumber, pageIndex }: PageNumber): void => {
@@ -172,8 +172,15 @@ export function useScrollContextProps(): IScrollContext {
   }, []);
 
   const getMaxVisibleElement = (visibleElements: Map<any, number>): any => {
-    const maxRatio = Math.max(...visibleElements.values(), 0);
-    return Object.keys(visibleElements).find(key => visibleElements.get(key) === maxRatio);
+    let maxPageNum = null;
+    let maxRatio = 0;
+    for (const [pageNum, ratio] of visibleElements) {
+      if (maxRatio < ratio) {
+        maxPageNum = pageNum;
+        maxRatio = ratio;
+      }
+    }
+    return maxPageNum;
   };
 
   // Watch outline nodes
@@ -204,7 +211,7 @@ export function useScrollContextProps(): IScrollContext {
     const root = scrollRoot || document.documentElement;
     const detector = new VisibleEntriesDetector<number>({
       root: root,
-      setVisibleEntries: setVisiblePageNumbers,
+      setVisibleEntries: setVisiblePageRatios,
       onVisibleEntriesChange: ({ visibleEntries, hiddenEntries, lastEntries }) => {
         hiddenEntries.map(entry =>
           lastEntries.delete(parseInt(entry.target?.getAttribute(PAGE_NUMBER_ATTRIBUTE) || '', 10))
@@ -230,7 +237,7 @@ export function useScrollContextProps(): IScrollContext {
     isPageVisible,
     scrollDirection,
     visibleOutlineTargets,
-    visiblePageNumbers,
+    visiblePageRatios,
     resetScrollObservers,
     setScrollRoot,
     scrollToOutlineTarget,

--- a/ui/library/src/utils/MaxVisibleElement.ts
+++ b/ui/library/src/utils/MaxVisibleElement.ts
@@ -1,10 +1,8 @@
 import { Nullable } from '../components/types/utils';
 
-type VisibleElementKey = Nullable<number | string>;
+type VisibleElement = Nullable<number | string>;
 
-export function getMaxVisibleElement(
-  visibleElements: Map<VisibleElementKey, number>
-): VisibleElementKey {
+export function getMaxVisibleElement(visibleElements: Map<VisibleElement, number>): VisibleElement {
   let maxVisibleKey = null;
   let maxRatio = 0;
   for (const [visibleKey, ratio] of visibleElements) {

--- a/ui/library/src/utils/MaxVisibleElement.ts
+++ b/ui/library/src/utils/MaxVisibleElement.ts
@@ -1,0 +1,17 @@
+import { Nullable } from '../components/types/utils';
+
+type VisibleElementKey = Nullable<number | string>;
+
+export function getMaxVisibleElement(
+  visibleElements: Map<VisibleElementKey, number>
+): VisibleElementKey {
+  let maxVisibleKey = null;
+  let maxRatio = 0;
+  for (const [visibleKey, ratio] of visibleElements) {
+    if (maxRatio < ratio) {
+      maxVisibleKey = visibleKey;
+      maxRatio = ratio;
+    }
+  }
+  return maxVisibleKey;
+}

--- a/ui/library/src/utils/VisibleEntriesDetector.ts
+++ b/ui/library/src/utils/VisibleEntriesDetector.ts
@@ -1,4 +1,7 @@
 const DEFAULT_ROOT_MARGIN = '50px';
+// This array is a range from 0.0001 to 1 range of threshold. It will help with detecting
+// on scroll with a better % compare to a fix threshold but not firing too frequent that
+// can hamper our performance.
 const DEFAULT_THRESHOLD = [0.0001, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.99];
 
 export type SetVisibleEntriesCallback<TEntry> = (visible: Map<TEntry, number>) => void;

--- a/ui/library/src/utils/VisibleEntriesDetector.ts
+++ b/ui/library/src/utils/VisibleEntriesDetector.ts
@@ -1,5 +1,5 @@
 const DEFAULT_ROOT_MARGIN = '50px';
-const DEFAULT_THRESHOLD = 0.00001;
+const DEFAULT_THRESHOLD = [0.0001, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.99];
 
 export type SetVisibleEntriesCallback<TEntry> = (visible: Map<TEntry, number>) => void;
 export type onVisibleEntriesChangeCallback<TEntry> = (args: {

--- a/ui/library/test/context/ScrollContext.test.tsx
+++ b/ui/library/test/context/ScrollContext.test.tsx
@@ -31,7 +31,6 @@ describe('<ScrollContext/>', () => {
   let _isOutlineTargetVisible: (dest: NodeDestination) => boolean;
   let _isPageVisible: (opts: PageNumber) => boolean;
   let _scrollToPage: (opts: PageNumber) => void;
-  let _getMaxVisibleElement: (visibleElements: Map<any, number>) => any;
 
   beforeEach(() => {
     (global as any).IntersectionObserver = function (...args) {
@@ -47,7 +46,7 @@ describe('<ScrollContext/>', () => {
               const {
                 scrollDirection,
                 visibleOutlineTargets,
-                visiblePageNumbers,
+                visiblePageRatios,
                 scrollThresholdReachedInDirection,
                 isAtTop,
                 setScrollRoot,
@@ -55,7 +54,6 @@ describe('<ScrollContext/>', () => {
                 isOutlineTargetVisible,
                 isPageVisible,
                 scrollToPage,
-                getMaxVisibleElement,
               } = args;
               // eslint-disable-next-line @typescript-eslint/no-unused-vars
               _setScrollRoot = setScrollRoot;
@@ -67,13 +65,11 @@ describe('<ScrollContext/>', () => {
               _isPageVisible = isPageVisible;
               // eslint-disable-next-line @typescript-eslint/no-unused-vars
               _scrollToPage = scrollToPage;
-              // eslint-disable-next-line @typescript-eslint/no-unused-vars
-              _getMaxVisibleElement = getMaxVisibleElement;
               return (
                 <div>
                   <div className="scrollDirection">{scrollDirection}</div>
                   <div className="visibleOutlineTargets">{visibleOutlineTargets}</div>
-                  <div className="visiblePageNumbers">{visiblePageNumbers}</div>
+                  <div className="visiblePageNumbers">{visiblePageRatios}</div>
                   <div className="scrollThresholdReachedInDirection">
                     {scrollThresholdReachedInDirection}
                   </div>

--- a/ui/library/test/utils/MaxVisibleElement.test.ts
+++ b/ui/library/test/utils/MaxVisibleElement.test.ts
@@ -1,0 +1,15 @@
+import { expect } from 'chai';
+
+import { getMaxVisibleElement } from '../../src/utils/MaxVisibleElement';
+
+describe('MaxVisibleElement', () => {
+  const map = new Map();
+  map.set(1, 0.00123);
+  map.set(2, 0.012567);
+  map.set(3, 0.2);
+
+  it('should return the correct key of the max visible element when getMaxVisibleElement get called', () => {
+    const maxVisibleElement = getMaxVisibleElement(map);
+    expect(maxVisibleElement).to.equal(3);
+  });
+});


### PR DESCRIPTION
## Description

Ref: https://github.com/allenai/scholar/issues/32921
Figma: https://www.figma.com/file/2gUmD3D8tz6gnm9rsYgj6J/Semantic-Reader

With the creation of ScrollContext completed, now its time to add the ability to track current page and allow user to enter the page they want to view and then it will scroll to there. This PR address all of the above functionality.

## Reviewer Instructions

Create a new component name PageNumberControl that will be imported to Semantic Reader in S2.  Change default Threshold to an array with a specific range suggest by Paul so it will fire more frequent but not too harmful to performance. Separate out the logic of `getMaxVisibleElement` into a util file and add unit test for it. Added `aria-label` for accessibility and verify it works with Screen Reader

## Testing Plan

Couple scenario to be test:

1. If user scroll through the PDF it will display the correct page they are on
2. If user types any letter it will display empty in the input box
3. if user enter a decimal number that is in range of the total pages it will round down and scroll to the page and also update the current page to that round down number
4. if user type a number in range of total pages it will scroll to that page
5. if the user type a number and unfocus of the input it will scroll to that page
6. Enter a number out of total range it wont do anything
7. Enter a negative number wont do anything

## Output / Screenshots

1. If user scroll through the PDF it will display the correct page they are on

https://user-images.githubusercontent.com/84343285/182477091-bbc83cb8-d688-47ec-b07e-a2eb27bcf073.mov

2. If user types any letter it will display empty in the input box (e works since it stands for exponential which is numeric)

https://user-images.githubusercontent.com/84343285/182477569-4b32c77e-c382-417c-883f-5e87cad5536d.mov

3. If user enter a decimal number that is in range of the total pages it will round down and scroll to the page and also update the current page to that round down number

https://user-images.githubusercontent.com/84343285/182477780-275814cf-156a-4a99-805a-258cfd022981.mov

4. If user type a number in range of total pages it will scroll to that page

https://user-images.githubusercontent.com/84343285/182477961-a5e60eba-ffd7-4a78-a957-23dda6b9912e.mov

5. If the user type a number and unfocus of the input it will scroll to that page

https://user-images.githubusercontent.com/84343285/182478292-d9f35830-1e33-4d1b-90af-6158d7258c5a.mov

6. Enter a number out of total range it wont do anything

https://user-images.githubusercontent.com/84343285/182483446-ea3c6198-50e2-4566-b476-c1809beaf8d3.mov

7. Enter a negative number wont do anything

https://user-images.githubusercontent.com/84343285/182483688-e3ec95e0-0293-43dc-978f-5dec308f1d8a.mov

### Browser 
1. Edge

https://user-images.githubusercontent.com/84343285/182687107-4d2fb31a-6800-436a-afa2-bf6f4ba7a2a5.mov

2. Firefox

https://user-images.githubusercontent.com/84343285/182688807-1874190d-15b9-42df-abc3-8a0aae87ed24.mov

3. Safari

https://user-images.githubusercontent.com/84343285/182697420-a6471b0d-0f11-4141-8cd2-ddcb462950bb.mov





### A11y

https://user-images.githubusercontent.com/84343285/182479551-c01f29c6-9fb6-498f-acd5-1f9e82638bd1.mov


