### PR TITLE
Fix scroll issue for PageNumberControl incase of unfocus in Prod

### DIFF
--- a/ui/library/src/components/PageNumberControl.tsx
+++ b/ui/library/src/components/PageNumberControl.tsx
@@ -73,8 +73,11 @@ export const PageNumberControl: React.FunctionComponent<Props> = ({ className }:
     if (Number.isNaN(pageNumber)) {
       return;
     }
-    scrollToPage({ pageNumber });
-  }, [userInput]);
+
+    delayTimerRef.current = setTimeout(() => {
+      scrollToPage({ pageNumber: pageNumber });
+    }, DELAY_SCROLL_TIME_OUT_MS);
+  }, [userInput, scrollToPage]);
 
   return (
     <div className={classnames('reader__page-number-control', className)}>


### PR DESCRIPTION
## Description

Ref: https://github.com/allenai/scholar/issues/32921
Figma: https://www.figma.com/file/2gUmD3D8tz6gnm9rsYgj6J/Semantic-Reader

When it comes to unfocus after typing the number it doesnt scroll to page except in debug mode. This PR address this. This PR needs to get in first before the S2 one

## Reviewer Instructions

The reason why it doesn't work in Prod because for scrollIntoView we need a setTimeout wrap around it like how when we type a number and it should scroll. 

## Testing Plan

Verify both prod & pdf component works. Yarn format, lint, test.

## Output / Screenshots

Local


https://user-images.githubusercontent.com/84343285/182758971-836cdf7f-abb7-44b4-b341-b737c38594a5.mov

Prod

https://user-images.githubusercontent.com/84343285/182759014-d099b0fb-84e9-4f8b-892e-bdc8fd87b9fe.mov




### A11y

No A11y involvement

