### PR TITLE
Fix scroll zoom bug

### DIFF
--- a/ui/library/src/components/DocumentWrapper.tsx
+++ b/ui/library/src/components/DocumentWrapper.tsx
@@ -23,8 +23,8 @@ export const DocumentWrapper: React.FunctionComponent<Props> = ({
 
   const { pdfDocProxy, setNumPages, setPageDimensions, setPdfDocProxy } =
     React.useContext(DocumentContext);
-  const { resetScrollObservers } = React.useContext(ScrollContext);
-  const { rotation } = React.useContext(TransformContext);
+  const { resetScrollObservers, resetScrollToTopOfPage } = React.useContext(ScrollContext);
+  const { rotation, scale } = React.useContext(TransformContext);
   const { setErrorMessage, setIsLoading } = React.useContext(UiContext);
 
   function getFirstPage(pdfDoc: pdfjs.PDFDocumentProxy): Promise<IPDFPageProxy> {
@@ -34,7 +34,13 @@ export const DocumentWrapper: React.FunctionComponent<Props> = ({
 
   React.useEffect(() => {
     resetScrollObservers();
-  }, []);
+  }, [pdfDocProxy]);
+
+  React.useEffect(() => {
+    // fix known react-pdf bug where zooming causes scroll position jump to a different page
+    console.log("v1");
+    resetScrollToTopOfPage();
+  }, [scale]);
 
   const onPdfLoadSuccess = React.useCallback((pdfDoc: pdfjs.PDFDocumentProxy): void => {
     setNumPages(pdfDoc.numPages);

--- a/ui/library/src/components/DocumentWrapper.tsx
+++ b/ui/library/src/components/DocumentWrapper.tsx
@@ -38,7 +38,6 @@ export const DocumentWrapper: React.FunctionComponent<Props> = ({
 
   React.useEffect(() => {
     // fix known react-pdf bug where zooming causes scroll position jump to a different page
-    console.log("v1");
     resetScrollToTopOfPage();
   }, [scale]);
 

--- a/ui/library/src/utils/VisibleEntriesDetector.ts
+++ b/ui/library/src/utils/VisibleEntriesDetector.ts
@@ -2,7 +2,15 @@ const DEFAULT_ROOT_MARGIN = '50px';
 // This array is a range from 0.0001 to 1 range of threshold. It will help with detecting
 // on scroll with a better % compare to a fix threshold but not firing too frequent that
 // can hamper our performance.
-const DEFAULT_THRESHOLD = [0.0001, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.99];
+const DEFAULT_THRESHOLD = [
+  0.0001, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1, 0.11, 0.12, 0.13, 0.14, 0.15,
+  0.16, 0.17, 0.18, 0.19, 0.2, 0.21, 0.22, 0.23, 0.24, 0.25, 0.26, 0.27, 0.28, 0.29, 0.3, 0.31,
+  0.32, 0.33, 0.34, 0.35, 0.36, 0.37, 0.38, 0.39, 0.4, 0.41, 0.42, 0.43, 0.44, 0.45, 0.46, 0.47,
+  0.48, 0.49, 0.5, 0.51, 0.52, 0.53, 0.54, 0.55, 0.56, 0.57, 0.58, 0.59, 0.6, 0.61, 0.62, 0.63,
+  0.64, 0.65, 0.66, 0.67, 0.68, 0.69, 0.7, 0.71, 0.72, 0.73, 0.74, 0.75, 0.76, 0.77, 0.78, 0.79,
+  0.8, 0.81, 0.82, 0.83, 0.84, 0.85, 0.86, 0.87, 0.88, 0.89, 0.9, 0.91, 0.92, 0.93, 0.94, 0.95,
+  0.96, 0.97, 0.98, 0.99,
+];
 
 export type SetVisibleEntriesCallback<TEntry> = (visible: Map<TEntry, number>) => void;
 export type onVisibleEntriesChangeCallback<TEntry> = (args: {


### PR DESCRIPTION
## Description

Fix known bug in react-pdf where zooming in/out causes the current scroll to jump to vastly different pages. This is most notable when at the bottom of the document

## Reviewer Instructions

Semantic Reader has an issue where the scroll observers arent loaded correctly, but is fixed when the TOC is opened. To fix this, I reset scroll observers on pdfDocProxy change inside of document wrapper. 

Note: this fix is reliant on visiblePageRatios which we will be tweaking in the future to be more consistent

## Testing Plan

Zoom in and out on first page, last page, middle page. Should zoom into the current page. 

## Output / Screenshots

### Before

https://user-images.githubusercontent.com/108751850/182953931-8993be71-e19e-4f31-bb76-012254dbf3c4.mov

### After

https://user-images.githubusercontent.com/108751850/182953939-e525de0b-7979-458e-8e3b-189b7829793e.mov

### A11y

N/A
