### PR TITLE
recalibrate scroll on zoom

### DIFF
--- a/ui/library/src/components/ZoomInButton.tsx
+++ b/ui/library/src/components/ZoomInButton.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
-import { TransformContext } from '../context/TransformContext';
 import { ScrollContext } from '../context/ScrollContext';
+import { TransformContext } from '../context/TransformContext';
 
 export type Props = {
   children?: React.ReactNode;
@@ -18,7 +18,7 @@ export const ZoomInButton: React.FunctionComponent<Props> = ({
     (event): void => {
       event.preventDefault();
       event.stopPropagation();
-      recalibrateScrollPosition(1 * zoomMultiplier)
+      recalibrateScrollPosition(1 * zoomMultiplier);
       setScale(scale * zoomMultiplier);
     },
     [scale, zoomMultiplier, recalibrateScrollPosition]

--- a/ui/library/src/components/ZoomInButton.tsx
+++ b/ui/library/src/components/ZoomInButton.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { TransformContext } from '../context/TransformContext';
+import { ScrollContext } from '../context/ScrollContext';
 
 export type Props = {
   children?: React.ReactNode;
@@ -11,14 +12,16 @@ export const ZoomInButton: React.FunctionComponent<Props> = ({
   ...extraProps
 }: Props) => {
   const { scale, setScale, zoomMultiplier } = React.useContext(TransformContext);
+  const { recalibrateScrollPosition } = React.useContext(ScrollContext);
 
   const handleZoomIn = React.useCallback(
     (event): void => {
       event.preventDefault();
       event.stopPropagation();
+      recalibrateScrollPosition(1 * zoomMultiplier)
       setScale(scale * zoomMultiplier);
     },
-    [scale, zoomMultiplier]
+    [scale, zoomMultiplier, recalibrateScrollPosition]
   );
 
   return (

--- a/ui/library/src/components/ZoomInButton.tsx
+++ b/ui/library/src/components/ZoomInButton.tsx
@@ -12,16 +12,16 @@ export const ZoomInButton: React.FunctionComponent<Props> = ({
   ...extraProps
 }: Props) => {
   const { scale, setScale, zoomMultiplier } = React.useContext(TransformContext);
-  const { recalibrateScrollPosition } = React.useContext(ScrollContext);
+  const { updateScrollPosition } = React.useContext(ScrollContext);
 
   const handleZoomIn = React.useCallback(
     (event): void => {
       event.preventDefault();
       event.stopPropagation();
-      recalibrateScrollPosition(1 * zoomMultiplier);
+      updateScrollPosition(1 * zoomMultiplier);
       setScale(scale * zoomMultiplier);
     },
-    [scale, zoomMultiplier, recalibrateScrollPosition]
+    [scale, zoomMultiplier, updateScrollPosition]
   );
 
   return (

--- a/ui/library/src/components/ZoomOutButton.tsx
+++ b/ui/library/src/components/ZoomOutButton.tsx
@@ -9,16 +9,16 @@ export type Props = {
 
 export const ZoomOutButton: React.FunctionComponent = ({ children, ...extraProps }: Props) => {
   const { scale, setScale, zoomMultiplier } = React.useContext(TransformContext);
-  const { recalibrateScrollPosition } = React.useContext(ScrollContext);
+  const { updateScrollPosition } = React.useContext(ScrollContext);
 
   const handleZoomOut = React.useCallback(
     (event): void => {
       event.preventDefault();
       event.stopPropagation();
-      recalibrateScrollPosition(1 / zoomMultiplier);
+      updateScrollPosition(1 / zoomMultiplier);
       setScale(scale / zoomMultiplier);
     },
-    [scale, zoomMultiplier, recalibrateScrollPosition]
+    [scale, zoomMultiplier, updateScrollPosition]
   );
 
   return (

--- a/ui/library/src/components/ZoomOutButton.tsx
+++ b/ui/library/src/components/ZoomOutButton.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
-import { TransformContext } from '../context/TransformContext';
 import { ScrollContext } from '../context/ScrollContext';
+import { TransformContext } from '../context/TransformContext';
 
 export type Props = {
   children?: React.ReactNode;

--- a/ui/library/src/components/ZoomOutButton.tsx
+++ b/ui/library/src/components/ZoomOutButton.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { TransformContext } from '../context/TransformContext';
+import { ScrollContext } from '../context/ScrollContext';
 
 export type Props = {
   children?: React.ReactNode;
@@ -8,14 +9,16 @@ export type Props = {
 
 export const ZoomOutButton: React.FunctionComponent = ({ children, ...extraProps }: Props) => {
   const { scale, setScale, zoomMultiplier } = React.useContext(TransformContext);
+  const { recalibrateScrollPosition } = React.useContext(ScrollContext);
 
   const handleZoomOut = React.useCallback(
     (event): void => {
       event.preventDefault();
       event.stopPropagation();
+      recalibrateScrollPosition(1 / zoomMultiplier);
       setScale(scale / zoomMultiplier);
     },
-    [scale, zoomMultiplier]
+    [scale, zoomMultiplier, recalibrateScrollPosition]
   );
 
   return (

--- a/ui/library/src/context/ScrollContext.ts
+++ b/ui/library/src/context/ScrollContext.ts
@@ -35,6 +35,7 @@ export interface IScrollContext {
   scrollToOutlineTarget: (dest: NodeDestination) => void;
   setScrollThreshold: (scrollThreshold: Nullable<number>) => void;
   scrollToPage: (pageNumber: PageNumber) => void;
+  recalibrateScrollPosition: (zoomMultiplier: number) => void;
   scrollThresholdReachedInDirection: Nullable<ScrollDirection>;
   isAtTop: Nullable<boolean>;
 }
@@ -65,6 +66,9 @@ const DEFAULT_CONTEXT: IScrollContext = {
   },
   scrollToPage: opts => {
     logProviderWarning(`scrollToPage(${JSON.stringify(opts)})`, 'ScrollContext');
+  },
+  recalibrateScrollPosition: zoomMultiplier => {
+    logProviderWarning(`recalibrateScrollPosition(${JSON.stringify(zoomMultiplier)})`, 'ScrollContext');
   },
   scrollThresholdReachedInDirection: null,
   isAtTop: null,
@@ -216,6 +220,19 @@ export function useScrollContextProps(): IScrollContext {
     };
   }, [scrollRoot, observerIndex]);
 
+  const recalibrateScrollPosition = React.useCallback((zoomMultiplier:number): void => {
+    // fix known react-pdf bug where zooming causes scroll position to jump to different pages  
+    const root = scrollRoot || document.documentElement;
+    if(!root) {
+      return;
+    } 
+    const newScrollTop = Math.floor(root.scrollTop * zoomMultiplier);
+    setTimeout(()=>{
+      root.scrollTop = newScrollTop;   
+    }, 1);
+}, [scrollRoot]); 
+
+
   return {
     isOutlineTargetVisible,
     isPageVisible,
@@ -227,6 +244,7 @@ export function useScrollContextProps(): IScrollContext {
     scrollToOutlineTarget,
     setScrollThreshold,
     scrollToPage,
+    recalibrateScrollPosition,
     scrollThresholdReachedInDirection,
     isAtTop,
   };

--- a/ui/library/src/context/ScrollContext.ts
+++ b/ui/library/src/context/ScrollContext.ts
@@ -68,10 +68,7 @@ const DEFAULT_CONTEXT: IScrollContext = {
     logProviderWarning(`scrollToPage(${JSON.stringify(opts)})`, 'ScrollContext');
   },
   updateScrollPosition: zoomMultiplier => {
-    logProviderWarning(
-      `updateScrollPosition(${JSON.stringify(zoomMultiplier)})`,
-      'ScrollContext'
-    );
+    logProviderWarning(`updateScrollPosition(${JSON.stringify(zoomMultiplier)})`, 'ScrollContext');
   },
   scrollThresholdReachedInDirection: null,
   isAtTop: null,
@@ -225,7 +222,7 @@ export function useScrollContextProps(): IScrollContext {
 
   // calculates a new scroll position after zooming in/out so user doesnt lose their position
   const updateScrollPosition = React.useCallback(
-    (zoomMultiplier: number): void => { 
+    (zoomMultiplier: number): void => {
       const root = scrollRoot || document.documentElement;
       if (!root) {
         return;

--- a/ui/library/src/context/ScrollContext.ts
+++ b/ui/library/src/context/ScrollContext.ts
@@ -35,7 +35,7 @@ export interface IScrollContext {
   scrollToOutlineTarget: (dest: NodeDestination) => void;
   setScrollThreshold: (scrollThreshold: Nullable<number>) => void;
   scrollToPage: (pageNumber: PageNumber) => void;
-  recalibrateScrollPosition: (zoomMultiplier: number) => void;
+  updateScrollPosition: (zoomMultiplier: number) => void;
   scrollThresholdReachedInDirection: Nullable<ScrollDirection>;
   isAtTop: Nullable<boolean>;
 }
@@ -67,9 +67,9 @@ const DEFAULT_CONTEXT: IScrollContext = {
   scrollToPage: opts => {
     logProviderWarning(`scrollToPage(${JSON.stringify(opts)})`, 'ScrollContext');
   },
-  recalibrateScrollPosition: zoomMultiplier => {
+  updateScrollPosition: zoomMultiplier => {
     logProviderWarning(
-      `recalibrateScrollPosition(${JSON.stringify(zoomMultiplier)})`,
+      `updateScrollPosition(${JSON.stringify(zoomMultiplier)})`,
       'ScrollContext'
     );
   },
@@ -223,9 +223,9 @@ export function useScrollContextProps(): IScrollContext {
     };
   }, [scrollRoot, observerIndex]);
 
-  const recalibrateScrollPosition = React.useCallback(
-    (zoomMultiplier: number): void => {
-      // fix known react-pdf bug where zooming causes scroll position to jump to different pages
+  // calculates a new scroll position after zooming in/out so user doesnt lose their position
+  const updateScrollPosition = React.useCallback(
+    (zoomMultiplier: number): void => { 
       const root = scrollRoot || document.documentElement;
       if (!root) {
         return;
@@ -233,7 +233,7 @@ export function useScrollContextProps(): IScrollContext {
       const newScrollTop = Math.floor(root.scrollTop * zoomMultiplier);
       setTimeout(() => {
         root.scrollTop = newScrollTop;
-      }, 1);
+      }, 0);
     },
     [scrollRoot]
   );
@@ -249,7 +249,7 @@ export function useScrollContextProps(): IScrollContext {
     scrollToOutlineTarget,
     setScrollThreshold,
     scrollToPage,
-    recalibrateScrollPosition,
+    updateScrollPosition,
     scrollThresholdReachedInDirection,
     isAtTop,
   };

--- a/ui/library/src/context/ScrollContext.ts
+++ b/ui/library/src/context/ScrollContext.ts
@@ -68,7 +68,10 @@ const DEFAULT_CONTEXT: IScrollContext = {
     logProviderWarning(`scrollToPage(${JSON.stringify(opts)})`, 'ScrollContext');
   },
   recalibrateScrollPosition: zoomMultiplier => {
-    logProviderWarning(`recalibrateScrollPosition(${JSON.stringify(zoomMultiplier)})`, 'ScrollContext');
+    logProviderWarning(
+      `recalibrateScrollPosition(${JSON.stringify(zoomMultiplier)})`,
+      'ScrollContext'
+    );
   },
   scrollThresholdReachedInDirection: null,
   isAtTop: null,
@@ -220,18 +223,20 @@ export function useScrollContextProps(): IScrollContext {
     };
   }, [scrollRoot, observerIndex]);
 
-  const recalibrateScrollPosition = React.useCallback((zoomMultiplier:number): void => {
-    // fix known react-pdf bug where zooming causes scroll position to jump to different pages  
-    const root = scrollRoot || document.documentElement;
-    if(!root) {
-      return;
-    } 
-    const newScrollTop = Math.floor(root.scrollTop * zoomMultiplier);
-    setTimeout(()=>{
-      root.scrollTop = newScrollTop;   
-    }, 1);
-}, [scrollRoot]); 
-
+  const recalibrateScrollPosition = React.useCallback(
+    (zoomMultiplier: number): void => {
+      // fix known react-pdf bug where zooming causes scroll position to jump to different pages
+      const root = scrollRoot || document.documentElement;
+      if (!root) {
+        return;
+      }
+      const newScrollTop = Math.floor(root.scrollTop * zoomMultiplier);
+      setTimeout(() => {
+        root.scrollTop = newScrollTop;
+      }, 1);
+    },
+    [scrollRoot]
+  );
 
   return {
     isOutlineTargetVisible,

--- a/ui/library/test/context/ScrollContext.test.tsx
+++ b/ui/library/test/context/ScrollContext.test.tsx
@@ -67,8 +67,8 @@ describe('<ScrollContext/>', () => {
               _isPageVisible = isPageVisible;
               // eslint-disable-next-line @typescript-eslint/no-unused-vars
               _scrollToPage = scrollToPage;
-               // eslint-disable-next-line @typescript-eslint/no-unused-vars
-               _recalibrateScrollPosition = recalibrateScrollPosition;
+              // eslint-disable-next-line @typescript-eslint/no-unused-vars
+              _recalibrateScrollPosition = recalibrateScrollPosition;
               return (
                 <div>
                   <div className="scrollDirection">{scrollDirection}</div>
@@ -112,12 +112,12 @@ describe('<ScrollContext/>', () => {
     expectTextFromClassName('isAtTop', '');
   });
   it('recalibrateScrollPosition sucessfully changes scroll position based on multiplier', () => {
-    _setScrollRoot(null); 
-    document.documentElement.scrollTop = 50; 
-    _recalibrateScrollPosition(1.2); 
-     
-    setTimeout(()=>{
-      expect(document.documentElement.scrollTop).to.equal(50 * 1.2); 
-    }, 5);  
-  }); 
+    _setScrollRoot(null);
+    document.documentElement.scrollTop = 50;
+    _recalibrateScrollPosition(1.2);
+
+    setTimeout(() => {
+      expect(document.documentElement.scrollTop).to.equal(50 * 1.2);
+    }, 5);
+  });
 });

--- a/ui/library/test/context/ScrollContext.test.tsx
+++ b/ui/library/test/context/ScrollContext.test.tsx
@@ -31,7 +31,7 @@ describe('<ScrollContext/>', () => {
   let _isOutlineTargetVisible: (dest: NodeDestination) => boolean;
   let _isPageVisible: (opts: PageNumber) => boolean;
   let _scrollToPage: (opts: PageNumber) => void;
-  let _recalibrateScrollPosition: (opts: number) => void;
+  let _updateScrollPosition: (opts: number) => void;
 
   beforeEach(() => {
     (global as any).IntersectionObserver = function (...args) {
@@ -55,7 +55,7 @@ describe('<ScrollContext/>', () => {
                 isOutlineTargetVisible,
                 isPageVisible,
                 scrollToPage,
-                recalibrateScrollPosition,
+                updateScrollPosition,
               } = args;
               // eslint-disable-next-line @typescript-eslint/no-unused-vars
               _setScrollRoot = setScrollRoot;
@@ -68,7 +68,7 @@ describe('<ScrollContext/>', () => {
               // eslint-disable-next-line @typescript-eslint/no-unused-vars
               _scrollToPage = scrollToPage;
               // eslint-disable-next-line @typescript-eslint/no-unused-vars
-              _recalibrateScrollPosition = recalibrateScrollPosition;
+              _updateScrollPosition = updateScrollPosition;
               return (
                 <div>
                   <div className="scrollDirection">{scrollDirection}</div>
@@ -111,10 +111,10 @@ describe('<ScrollContext/>', () => {
   it('provides a default isAtTop', () => {
     expectTextFromClassName('isAtTop', '');
   });
-  it('recalibrateScrollPosition sucessfully changes scroll position based on multiplier', () => {
+  it('updateScrollPosition sucessfully changes scroll position based on multiplier', () => {
     _setScrollRoot(null);
     document.documentElement.scrollTop = 50;
-    _recalibrateScrollPosition(1.2);
+    _updateScrollPosition(1.2);
 
     setTimeout(() => {
       expect(document.documentElement.scrollTop).to.equal(50 * 1.2);

--- a/ui/library/test/context/ScrollContext.test.tsx
+++ b/ui/library/test/context/ScrollContext.test.tsx
@@ -31,6 +31,7 @@ describe('<ScrollContext/>', () => {
   let _isOutlineTargetVisible: (dest: NodeDestination) => boolean;
   let _isPageVisible: (opts: PageNumber) => boolean;
   let _scrollToPage: (opts: PageNumber) => void;
+  let _recalibrateScrollPosition: (opts: number) => void;
 
   beforeEach(() => {
     (global as any).IntersectionObserver = function (...args) {
@@ -54,6 +55,7 @@ describe('<ScrollContext/>', () => {
                 isOutlineTargetVisible,
                 isPageVisible,
                 scrollToPage,
+                recalibrateScrollPosition,
               } = args;
               // eslint-disable-next-line @typescript-eslint/no-unused-vars
               _setScrollRoot = setScrollRoot;
@@ -65,6 +67,8 @@ describe('<ScrollContext/>', () => {
               _isPageVisible = isPageVisible;
               // eslint-disable-next-line @typescript-eslint/no-unused-vars
               _scrollToPage = scrollToPage;
+               // eslint-disable-next-line @typescript-eslint/no-unused-vars
+               _recalibrateScrollPosition = recalibrateScrollPosition;
               return (
                 <div>
                   <div className="scrollDirection">{scrollDirection}</div>
@@ -107,4 +111,13 @@ describe('<ScrollContext/>', () => {
   it('provides a default isAtTop', () => {
     expectTextFromClassName('isAtTop', '');
   });
+  it('recalibrateScrollPosition sucessfully changes scroll position based on multiplier', () => {
+    _setScrollRoot(null); 
+    document.documentElement.scrollTop = 50; 
+    _recalibrateScrollPosition(1.2); 
+     
+    setTimeout(()=>{
+      expect(document.documentElement.scrollTop).to.equal(50 * 1.2); 
+    }, 5);  
+  }); 
 });


### PR DESCRIPTION
## Description

Fix known bug with react-pdf where zooming causes the scroll position to jump to different pages. 

## Reviewer Instructions


## Testing Plan

Tested this on first page, middle page, and last page on both the demo and Semantic Reader

## Output / Screenshots

### Before

https://user-images.githubusercontent.com/108751850/182987245-c1e16199-778e-4efe-8fcc-28ec5b31ed8c.mov

### After
 
https://user-images.githubusercontent.com/108751850/182987367-985cc9ff-2653-4dc4-9d84-d7c2af8c91a5.mov

### A11y

N/A
