### PR TITLE
Add page render context and use it logic in PageWrapper in PDF Component

### DIFF
--- a/ui/library/src/components/types/page.ts
+++ b/ui/library/src/components/types/page.ts
@@ -14,3 +14,12 @@ export type PageProperties = {
   marginLeft: number;
   marginRight: number;
 };
+
+/**
+ * pageNumber: number starts from 1
+ * pageIndex: number starts from 0
+ */
+export type PageNumber = {
+  pageNumber?: number;
+  pageIndex?: number;
+};

--- a/ui/library/src/context/ContextProvider.tsx
+++ b/ui/library/src/context/ContextProvider.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { DocumentContext, useDocumentContextProps } from './DocumentContext';
+import { PageRenderContext, usePageRenderContextProps } from './PageRenderContext';
 import { ScrollContext, useScrollContextProps } from './ScrollContext';
 import { TransformContext, useTransformContextProps } from './TransformContext';
 import { UiContext, useUiContextProps } from './UiContext';
@@ -14,12 +15,23 @@ export const ContextProvider: React.FunctionComponent<Props> = ({ children }: Pr
   const transformProps = useTransformContextProps();
   const uiProps = useUiContextProps();
   const scrollProps = useScrollContextProps();
+  const pageRenderProps = usePageRenderContextProps({
+    pdfDocProxy: documentProps.pdfDocProxy,
+    scale: transformProps.scale,
+    rotation: transformProps.rotation,
+    zoomMultiplier: transformProps.zoomMultiplier,
+    visiblePageRatios: scrollProps.visiblePageRatios,
+  });
 
   return (
     <DocumentContext.Provider value={documentProps}>
       <TransformContext.Provider value={transformProps}>
         <UiContext.Provider value={uiProps}>
-          <ScrollContext.Provider value={scrollProps}>{children}</ScrollContext.Provider>
+          <ScrollContext.Provider value={scrollProps}>
+            <PageRenderContext.Provider value={pageRenderProps}>
+              {children}
+            </PageRenderContext.Provider>
+          </ScrollContext.Provider>
         </UiContext.Provider>
       </TransformContext.Provider>
     </DocumentContext.Provider>

--- a/ui/library/src/context/PageRenderContext.ts
+++ b/ui/library/src/context/PageRenderContext.ts
@@ -69,7 +69,7 @@ export function usePageRenderContextProps({
   );
 
   const isBuildingObjectURLForPage = React.useCallback(
-    ({ pageNumber, pageIndex }: { pageNumber?: number; pageIndex?: number }): boolean => {
+    ({ pageNumber, pageIndex }: PageNumber): boolean => {
       if (typeof pageIndex === 'number') {
         pageNumber = pageIndex + 1;
       }
@@ -86,7 +86,7 @@ export function usePageRenderContextProps({
   );
 
   const getObjectURLForPage = React.useCallback(
-    ({ pageNumber, pageIndex }: { pageNumber?: number; pageIndex?: number }): Nullable<string> => {
+    ({ pageNumber, pageIndex }: PageNumber): Nullable<string> => {
       if (typeof pageIndex === 'number') {
         pageNumber = pageIndex + 1;
       }

--- a/ui/library/src/context/PageRenderContext.ts
+++ b/ui/library/src/context/PageRenderContext.ts
@@ -4,6 +4,7 @@ import { pdfjs } from 'react-pdf';
 import { Nullable } from '../components/types/utils';
 import { logProviderWarning } from '../utils/provider';
 import { PageRotation } from '../utils/rotate';
+import { PageNumber } from './ScrollContext';
 
 export type RenderState = {
   promise: Promise<string>;
@@ -14,9 +15,9 @@ export type PageNumberToRenderStateMap = Map<number, RenderState>;
 
 export interface IPageRenderContext {
   pageRenderStates: PageNumberToRenderStateMap;
-  getObjectURLForPage: (args: { pageNumber?: number; pageIndex?: number }) => Nullable<string>;
-  isBuildingObjectURLForPage: (args: { pageNumber?: number; pageIndex?: number }) => boolean;
-  buildObjectURLForPage: (args: { pageNumber?: number; pageIndex?: number }) => Promise<string>;
+  getObjectURLForPage: (pageNumber: PageNumber) => Nullable<string>;
+  isBuildingObjectURLForPage: (pageNumber: PageNumber) => boolean;
+  buildObjectURLForPage: (pageNumber: PageNumber) => Promise<string>;
 }
 
 export const PageRenderContext = React.createContext<IPageRenderContext>({
@@ -68,7 +69,7 @@ export function usePageRenderContextProps({
   );
 
   const isBuildingObjectURLForPage = React.useCallback(
-    ({ pageNumber, pageIndex }: { pageNumber?: number; pageIndex?: number }): boolean => {
+    ({ pageNumber, pageIndex }: PageNumber): boolean => {
       if (typeof pageIndex === 'number') {
         pageNumber = pageIndex + 1;
       }
@@ -85,7 +86,7 @@ export function usePageRenderContextProps({
   );
 
   const getObjectURLForPage = React.useCallback(
-    ({ pageNumber, pageIndex }: { pageNumber?: number; pageIndex?: number }): Nullable<string> => {
+    ({ pageNumber, pageIndex }: PageNumber): Nullable<string> => {
       if (typeof pageIndex === 'number') {
         pageNumber = pageIndex + 1;
       }
@@ -98,7 +99,7 @@ export function usePageRenderContextProps({
   );
 
   const buildObjectURLForPage = React.useCallback(
-    ({ pageNumber, pageIndex }: { pageNumber?: number; pageIndex?: number }): Promise<string> => {
+    ({ pageNumber, pageIndex }: PageNumber): Promise<string> => {
       if (typeof pageIndex === 'number') {
         pageNumber = pageIndex + 1;
       }

--- a/ui/library/src/context/PageRenderContext.ts
+++ b/ui/library/src/context/PageRenderContext.ts
@@ -1,0 +1,245 @@
+import * as React from 'react';
+import { pdfjs } from 'react-pdf';
+
+import { Nullable } from '../components/types/utils';
+import { logProviderWarning } from '../utils/provider';
+import { PageRotation } from '../utils/rotate';
+import { PageNumber } from './ScrollContext';
+
+export type RenderState = {
+  promise: Promise<string>;
+  objectURL: Nullable<string>;
+};
+
+export type PageNumberToRenderStateMap = Map<number, RenderState>;
+
+export interface IPageRenderContext {
+  pageRenderStates: PageNumberToRenderStateMap;
+  getObjectURLForPage: (args: PageNumber) => Nullable<string>;
+  isBuildingObjectURLForPage: (args: PageNumber) => boolean;
+  buildObjectURLForPage: (args: PageNumber) => Promise<string>;
+}
+
+export const PageRenderContext = React.createContext<IPageRenderContext>({
+  pageRenderStates: new Map(),
+  getObjectURLForPage: args => {
+    logProviderWarning(`getObjectURLForPage(${JSON.stringify(args)})`, 'PageRenderContext');
+    return null;
+  },
+  isBuildingObjectURLForPage: args => {
+    logProviderWarning(`isBuildingObjectURLForPage(${JSON.stringify(args)})`, 'PageRenderContext');
+    return false;
+  },
+  buildObjectURLForPage: args => {
+    logProviderWarning(`buildObjectURLForPage(${JSON.stringify(args)})`, 'PageRenderContext');
+    return Promise.resolve('');
+  },
+});
+
+export function usePageRenderContextProps({
+  pdfDocProxy,
+  scale,
+  rotation,
+  zoomMultiplier,
+  visiblePageRatios: visiblePageRatios,
+}: {
+  pdfDocProxy?: pdfjs.PDFDocumentProxy;
+  scale: number;
+  rotation: PageRotation;
+  zoomMultiplier: number;
+  visiblePageRatios: Map<number, number>;
+}): IPageRenderContext {
+  const [pageRenderStates, _setPageRenderStates] = React.useState<PageNumberToRenderStateMap>(
+    () => {
+      const map = new Map();
+      Object.freeze(map);
+      return map;
+    }
+  );
+
+  // Because rendering a page is async, we will lose the current pageRenderStates
+  // This ref trick allows the latest to be accessible when the objectURL is ready
+  const pageRenderStatesRef = React.useRef(pageRenderStates);
+  const setPageRenderStates = React.useCallback(
+    (pageRenderStates: PageNumberToRenderStateMap) => {
+      pageRenderStatesRef.current = pageRenderStates;
+      _setPageRenderStates(pageRenderStates);
+    },
+    [pageRenderStatesRef]
+  );
+
+  const isBuildingObjectURLForPage = React.useCallback(
+    ({ pageNumber, pageIndex }: { pageNumber?: number; pageIndex?: number }): boolean => {
+      if (typeof pageIndex === 'number') {
+        pageNumber = pageIndex + 1;
+      }
+      if (typeof pageNumber !== 'number') {
+        return false;
+      }
+      const state = pageRenderStates.get(pageNumber);
+      if (!state) {
+        return false;
+      }
+      return !state.objectURL;
+    },
+    [pageRenderStates]
+  );
+
+  const getObjectURLForPage = React.useCallback(
+    ({ pageNumber, pageIndex }: { pageNumber?: number; pageIndex?: number }): Nullable<string> => {
+      if (typeof pageIndex === 'number') {
+        pageNumber = pageIndex + 1;
+      }
+      if (typeof pageNumber !== 'number') {
+        return null;
+      }
+      return pageRenderStates.get(pageNumber)?.objectURL || null;
+    },
+    [pageRenderStates]
+  );
+
+  const buildObjectURLForPage = React.useCallback(
+    ({ pageNumber, pageIndex }: PageNumber): Promise<string> => {
+      if (typeof pageIndex === 'number') {
+        pageNumber = pageIndex + 1;
+      }
+      if (typeof pageNumber !== 'number') {
+        throw new Error('prop "pageNumber" is not a number');
+      }
+      if (!pdfDocProxy) {
+        throw new Error('cannot build a page until a "pdfDocProxy" is set on DocumentContext');
+      }
+
+      // Don't need to start another task if already rendered
+      const existingPromise = pageRenderStates.get(pageNumber)?.promise;
+      if (existingPromise) {
+        return existingPromise;
+      }
+
+      const promise = buildPageObjectURL({
+        pageNumber,
+        pdfDocProxy,
+        scale,
+        rotation,
+        zoomMultiplier,
+      });
+      const renderState: RenderState = {
+        promise,
+        objectURL: null,
+      };
+      promise.then(objectURL => {
+        renderState.objectURL = objectURL;
+        const newPageRenderStates = new Map(pageRenderStatesRef.current);
+        Object.freeze(newPageRenderStates);
+        setPageRenderStates(newPageRenderStates);
+      });
+      const newPageRenderStates = new Map(pageRenderStatesRef.current);
+      newPageRenderStates.set(pageNumber, renderState);
+      Object.freeze(newPageRenderStates);
+      setPageRenderStates(newPageRenderStates);
+      return promise;
+    },
+    [pageRenderStates, pdfDocProxy, scale, rotation, zoomMultiplier]
+  );
+
+  React.useEffect(() => {
+    for (const pageNumber of visiblePageRatios.keys()) {
+      if (pageRenderStates.has(pageNumber)) {
+        continue;
+      }
+      buildObjectURLForPage({ pageNumber });
+    }
+  }, [pageRenderStates, visiblePageRatios]);
+
+  return {
+    pageRenderStates,
+    getObjectURLForPage,
+    isBuildingObjectURLForPage,
+    buildObjectURLForPage,
+  };
+}
+
+// Generate an object url for a given page, rendered in a shared canvas
+async function buildPageObjectURL({
+  pageNumber,
+  pdfDocProxy,
+  scale = 1,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  rotation = PageRotation.Rotate0,
+  zoomMultiplier = 1.2,
+  imageType = 'image/png',
+  imageQuality = 1.0,
+}: {
+  pageNumber: number;
+  pdfDocProxy: pdfjs.PDFDocumentProxy;
+  scale?: number;
+  rotation?: PageRotation;
+  zoomMultiplier?: number;
+  imageType?: string;
+  imageQuality?: number;
+}): Promise<string> {
+  const pageProxy = await pdfDocProxy.getPage(pageNumber);
+
+  const blob: Nullable<Blob> = await useRenderCanvas(async canvas => {
+    // Render page in a canvas
+    const viewport = pageProxy.getViewport({ scale: scale * zoomMultiplier * devicePixelRatio });
+    canvas.height = viewport.height;
+    canvas.width = viewport.width;
+    const canvasContext = canvas.getContext('2d');
+    if (!canvasContext) {
+      throw new Error('canvas was unable to get a context');
+    }
+
+    const renderTask = pageProxy.render({
+      canvasContext,
+      viewport,
+    });
+    await renderTask.promise;
+
+    // allow a timeout on the render task
+    await new Promise(res => setTimeout(res, 16));
+
+    // Fetch a blob for an image of the canvas
+    return new Promise((resolve, reject) => {
+      try {
+        canvas.toBlob(blob => resolve(blob), imageType, imageQuality);
+      } catch (error) {
+        reject(error);
+      }
+    });
+  });
+
+  // Convert blob image to object url
+  if (!blob) {
+    throw new Error('unable to create image from page');
+  }
+  return URL.createObjectURL(blob);
+}
+
+let renderCanvas: Nullable<HTMLCanvasElement> = null;
+
+// Get or create a shared canvas for rendering pages in
+function getRenderCanvas(): HTMLCanvasElement {
+  if (!renderCanvas) {
+    renderCanvas = document.createElement('canvas');
+  }
+  return renderCanvas;
+}
+
+let nextCanvasUse: Promise<any> = Promise.resolve();
+
+// Use the shared canvas to render a page, using promises to create a queue
+async function useRenderCanvas<T>(callback: (canvas: HTMLCanvasElement) => Promise<T>): Promise<T> {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  let resolve = (_value: T | PromiseLike<T>) => {};
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  let reject = (_reason: any) => {};
+  const prom = new Promise<T>((_resolve, _reject) => {
+    resolve = _resolve;
+    reject = _reject;
+  });
+  nextCanvasUse = nextCanvasUse.then(() => callback(getRenderCanvas()).then(resolve, reject));
+  const result = await prom;
+  await new Promise(res => setTimeout(res, 16)); // Give some time between renders
+  return result;
+}

--- a/ui/library/src/context/PageRenderContext.ts
+++ b/ui/library/src/context/PageRenderContext.ts
@@ -62,7 +62,6 @@ export function usePageRenderContextProps({
   const setPageRenderStates = React.useCallback(
     (pageRenderStates: PageNumberToRenderStateMap) => {
       pageRenderStatesRef.current = pageRenderStates;
-      console.log('setting page render states', [...pageRenderStates.keys()].join(', '));
       _setPageRenderStates(pageRenderStates);
     },
     [pageRenderStatesRef]
@@ -128,7 +127,6 @@ export function usePageRenderContextProps({
         objectURL: null,
       };
       promise.then(objectURL => {
-        console.log(`Rendered page ${pageNumber}`, objectURL);
         renderState.objectURL = objectURL;
         const newPageRenderStates = new Map(pageRenderStatesRef.current);
         Object.freeze(newPageRenderStates);
@@ -165,6 +163,7 @@ async function buildPageObjectURL({
   pageNumber,
   pdfDocProxy,
   scale = 1,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   rotation = PageRotation.Rotate0,
   zoomMultiplier = 1.2,
   imageType = 'image/png',
@@ -178,10 +177,6 @@ async function buildPageObjectURL({
   imageType?: string;
   imageQuality?: number;
 }): Promise<string> {
-  console.log(`Rendering page ${pageNumber}`, {
-    scale,
-    rotation,
-  });
   const pageProxy = await pdfDocProxy.getPage(pageNumber);
 
   const blob: Nullable<Blob> = await useRenderCanvas(async canvas => {

--- a/ui/library/src/context/PageRenderContext.ts
+++ b/ui/library/src/context/PageRenderContext.ts
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { pdfjs } from 'react-pdf';
 
+import { PageNumber } from '../components/types/page';
 import { Nullable } from '../components/types/utils';
 import { logProviderWarning } from '../utils/provider';
 import { PageRotation } from '../utils/rotate';
-import { PageNumber } from './ScrollContext';
 
 export type RenderState = {
   promise: Promise<string>;

--- a/ui/library/src/context/ScrollContext.ts
+++ b/ui/library/src/context/ScrollContext.ts
@@ -1,20 +1,12 @@
 import * as React from 'react';
 
 import { NodeDestination } from '../components/types/outline';
+import { PageNumber } from '../components/types/page';
 import { Nullable } from '../components/types/utils';
 import { logProviderWarning } from '../utils/provider';
 import { generatePageIdFromIndex } from '../utils/scroll';
 import ScrollDetector, { ScrollDirection } from '../utils/ScrollDirectionDetector';
 import VisibleEntriesDetector from '../utils/VisibleEntriesDetector';
-
-/**
- * pageNumber: number starts from 1
- * pageIndex: number starts from 0
- */
-export type PageNumber = {
-  pageNumber?: number;
-  pageIndex?: number;
-};
 
 const OUTLINE_ATTRIBUTE = 'data-outline-target-dest';
 

--- a/ui/library/test/context/ContextProvider.test.tsx
+++ b/ui/library/test/context/ContextProvider.test.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import { Nullable } from '../../src/components/types/utils';
 import { ContextProvider } from '../../src/context/ContextProvider';
 import { DocumentContext, IDocumentContext } from '../../src/context/DocumentContext';
+import { IPageRenderContext, PageRenderContext } from '../../src/context/PageRenderContext';
 import { IScrollContext, ScrollContext } from '../../src/context/ScrollContext';
 import { ITransformContext, TransformContext } from '../../src/context/TransformContext';
 import { IUiContext, UiContext } from '../../src/context/UiContext';
@@ -16,6 +17,7 @@ describe('<ContextProvider/>', () => {
   let transformContextProps: Nullable<ITransformContext> = null;
   let uiContextProps: Nullable<IUiContext> = null;
   let scrollContextProps: Nullable<IScrollContext> = null;
+  let pageRenderContextProps: Nullable<IPageRenderContext> = null;
 
   before(() => {
     (global as any).IntersectionObserver = function (...args) {
@@ -48,6 +50,12 @@ describe('<ContextProvider/>', () => {
             return null;
           }}
         </ScrollContext.Consumer>
+        <PageRenderContext.Consumer>
+          {(args: IPageRenderContext) => {
+            pageRenderContextProps = args;
+            return null;
+          }}
+        </PageRenderContext.Consumer>
       </ContextProvider>
     );
   });
@@ -69,7 +77,11 @@ describe('<ContextProvider/>', () => {
     expect(uiContextProps).to.be.ok;
   });
 
-  it('should create a ScrollContext', () => {
+  it('should create a PageRenderContext', () => {
     expect(scrollContextProps).to.be.ok;
+  });
+
+  it('should create a ScrollContext', () => {
+    expect(pageRenderContextProps).to.be.ok;
   });
 });

--- a/ui/library/test/context/PageRenderContext.test.tsx
+++ b/ui/library/test/context/PageRenderContext.test.tsx
@@ -1,0 +1,80 @@
+import { expect } from 'chai';
+import { mount, ReactWrapper } from 'enzyme';
+import * as React from 'react';
+
+import { Nullable } from '../../src/components/types/utils';
+import {
+  IPageRenderContext,
+  PageRenderContext,
+  usePageRenderContextProps,
+} from '../../src/context/PageRenderContext';
+import { PageNumber } from '../../src/context/ScrollContext';
+import { PageRotation } from '../../src/utils/rotate';
+
+describe('<PageRenderContext/>', () => {
+  let wrapper: ReactWrapper;
+  const pdfDocProxy = undefined;
+  const scale = 0;
+  const rotation: PageRotation = PageRotation.Rotate0;
+  const zoomMultiplier = 0;
+  const visiblePageRatios: Map<number, number> = new Map();
+
+  function expectTextFromClassName(className: string, value: string | number | boolean | null) {
+    const actual = wrapper.find(`.${className}`).text();
+    const message = `Expected text for element with class .${className} to be ${value} instead of ${actual}`;
+    expect(actual).equals(`${value}`, message);
+  }
+
+  function UseContext({ children }: any) {
+    const contextProps = usePageRenderContextProps({
+      pdfDocProxy: pdfDocProxy,
+      scale: scale,
+      rotation: rotation,
+      zoomMultiplier: zoomMultiplier,
+      visiblePageRatios: visiblePageRatios,
+    });
+    return <PageRenderContext.Provider value={contextProps}>{children}</PageRenderContext.Provider>;
+  }
+
+  let _getObjectURLForPage: (args: PageNumber) => Nullable<string>;
+  let _isBuildingObjectURLForPage: (args: PageNumber) => boolean;
+  let _buildObjectURLForPage: (args: PageNumber) => Promise<string>;
+
+  beforeEach(() => {
+    wrapper = mount(
+      <div>
+        <UseContext>
+          <PageRenderContext.Consumer>
+            {(args: IPageRenderContext) => {
+              const {
+                pageRenderStates,
+                getObjectURLForPage,
+                isBuildingObjectURLForPage,
+                buildObjectURLForPage,
+              } = args;
+              // eslint-disable-next-line @typescript-eslint/no-unused-vars
+              _getObjectURLForPage = getObjectURLForPage;
+              // eslint-disable-next-line @typescript-eslint/no-unused-vars
+              _isBuildingObjectURLForPage = isBuildingObjectURLForPage;
+              // eslint-disable-next-line @typescript-eslint/no-unused-vars
+              _buildObjectURLForPage = buildObjectURLForPage;
+              return (
+                <div>
+                  <div className="pageRenderStates">{pageRenderStates}</div>
+                </div>
+              );
+            }}
+          </PageRenderContext.Consumer>
+        </UseContext>
+      </div>
+    );
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  it('provides a default pageRenderStates', () => {
+    expectTextFromClassName('pageRenderStates', '');
+  });
+});


### PR DESCRIPTION
## Description

Ref: https://github.com/allenai/scholar/issues/32835

After getting tracking page in & beta v6 of `react-pdf`. The next step is to improve our loading time and performance for Safari by using single canvas and each page become a URL link background image.

## Reviewer Instructions

Add the` PageRenderContext.ts` and applied the logic for `PageWrapper.tsx `and verified that each page is rendering as background image as showing by Paul last time. Per discussion with Paul we cant unit test the PageRenderContext due to pdf worker external cant be run local (its vital since PageRenderContext use `pdfDocProxy` and also mocking `canvas` is also difficult) so im only creating the `PageRenderContext.test.ts`. @yensung attached video about Safari performance as u can see now its more fluid not lagging and we can perform stuff on it.

## Testing Plan

Verify console.log print out objectURL and open development tool to verify that each page is rendering as background image 
## Output / Screenshots

![image](https://user-images.githubusercontent.com/84343285/183961685-4732cc1f-0ffe-4729-ab7e-f4bf12ae63b3.png)

![image](https://user-images.githubusercontent.com/84343285/183961775-0543360b-75d6-498b-bec2-483d63b27847.png)

Safari Performance

https://user-images.githubusercontent.com/84343285/184935739-546b706d-2d50-44d8-be59-abf5098c2cd8.mov

Safari Performance on Prod

https://user-images.githubusercontent.com/84343285/184945150-0faf576f-4533-4409-9dc9-321797544b04.mov

### A11y

N/A
