### PR TITLE
Adding renderMode to allow 1 rendering canvas instead multiple

### DIFF
--- a/ui/library/src/components/DocumentWrapper.tsx
+++ b/ui/library/src/components/DocumentWrapper.tsx
@@ -84,6 +84,7 @@ export const DocumentWrapper: React.FunctionComponent<Props> = ({
       onLoadError={onPdfLoadError}
       onLoadSuccess={onPdfLoadSuccess}
       externalLinkTarget="_blank"
+      renderMode="none"
       // @ts-ignore: the arguments should be { dest, pageIndex, pageNumber }
       // @types/react-pdf hasn't updated the function signature
       // https://github.com/DefinitelyTyped/DefinitelyTyped/blob/d73eb652e0ba8f89395a0ef2ba69cf1e640ce5be/types/react-pdf/dist/Document.d.ts#L72


### PR DESCRIPTION
## Description

Ref: https://github.com/allenai/scholar/issues/32835

On Prod there still multiple canvas rendering now. This PR addresses it.

## Reviewer Instructions

The reason for this to be happened because during the implementation i forgot to add `renderMode="none"` on Document element in `DocumentWrapper.tsx`

## Testing Plan

run `document.querySelectorAll('.react-pdf__Document canvas').length` to verify there will not be x amount of canvas depend on the page 

## Output / Screenshots

### Before


![image](https://user-images.githubusercontent.com/84343285/185255047-078e5a09-9cc3-4dc8-940a-6385611a07b0.png)



### After


https://user-images.githubusercontent.com/84343285/181393406-eeadb6b8-85fe-4123-8876-c86d0448af63.mov



### A11y

No A11y involvement
