### PR TITLE
Adding loading message for page that has a lot of image in PDF Component 

### DIFF
--- a/ui/library/less/colors.less
+++ b/ui/library/less/colors.less
@@ -3,3 +3,4 @@
 @pdflib-highlight-background: #ccb300;
 @initial-blue: #1857B6;
 @hover-active-blue: #5492EF; 
+@loading-outline-yellow: #F4D35E;

--- a/ui/library/less/styles.less
+++ b/ui/library/less/styles.less
@@ -53,6 +53,22 @@
   }
 }
 
+.reader__page--is-building-page-image {
+  outline: 2px solid @loading-outline-yellow;
+}
+
+.reader__page--is-loading-image {
+  align-items: center;
+  background-color: @loading-outline-yellow;
+  justify-content:center;
+  height: 24px;
+  margin: 0 auto;
+  padding: 0px 12px;
+  text-align: center;
+  top: 0;
+  width: 125px;
+}
+
 .reader__page-highlight-overlay {
   pointer-events: none;
   position: absolute;

--- a/ui/library/src/components/PageWrapper.tsx
+++ b/ui/library/src/components/PageWrapper.tsx
@@ -73,7 +73,7 @@ export const PageWrapper: React.FunctionComponent<Props> = ({
         'reader__page',
         { 'reader__page--has-page-image': objectURLForPage },
         { 'reader__page--no-page-image': !objectURLForPage },
-        { 'reader__page--is-building-page-image': true }
+        { 'reader__page--is-building-page-image': isBuildingPageImage }
       )}
       data-page-number={pageIndex + 1}
       style={getPageStyle()}

--- a/ui/library/src/components/PageWrapper.tsx
+++ b/ui/library/src/components/PageWrapper.tsx
@@ -23,6 +23,7 @@ export type PageProps = {
 
 export type Props = {
   className?: string;
+  loadingContentForBuildingImage?: string;
   children?: React.ReactElement<typeof HighlightOverlay | typeof Overlay>;
 } & PageProps;
 
@@ -30,6 +31,7 @@ export const PageWrapper: React.FunctionComponent<Props> = ({
   children,
   error,
   loading,
+  loadingContentForBuildingImage,
   noData,
   pageIndex,
   ...extraProps
@@ -71,12 +73,18 @@ export const PageWrapper: React.FunctionComponent<Props> = ({
         'reader__page',
         { 'reader__page--has-page-image': objectURLForPage },
         { 'reader__page--no-page-image': !objectURLForPage },
-        { 'reader__page--is-building-page-image': isBuildingPageImage }
+        { 'reader__page--is-building-page-image': true }
       )}
       data-page-number={pageIndex + 1}
       style={getPageStyle()}
       {...extraProps}>
       {children}
+      <div
+        className={classnames('reader__page', {
+          'reader__page--is-loading-image': isBuildingPageImage,
+        })}>
+        {loadingContentForBuildingImage}
+      </div>
       <Page
         width={getWidth()}
         error={error}

--- a/ui/library/src/components/PageWrapper.tsx
+++ b/ui/library/src/components/PageWrapper.tsx
@@ -23,7 +23,7 @@ export type PageProps = {
 
 export type Props = {
   className?: string;
-  loadingContentForBuildingImage?: string;
+  loadingContentForBuildingImage?: React.ReactElement;
   children?: React.ReactElement<typeof HighlightOverlay | typeof Overlay>;
 } & PageProps;
 


### PR DESCRIPTION
## Description

Ref: https://github.com/allenai/scholar/issues/33272
Figma: https://www.figma.com/file/2gUmD3D8tz6gnm9rsYgj6J/Semantic-Reader?node-id=3567%3A38013

Part 2 of the above ticket. After rendering the test first and while image is still loading, based on @ctrier design we will wrap the page in a yellow box with a text box in the middle to indicate its loading.

## Reviewer Instructions

After rendering the test first and while image is still loading, based on @ctrier design we will wrap the page in a yellow box with a text box in the middle to indicate its loading.  Now the message box in top middle of the page is just empty because i will pass a content to that box to show it.

## Testing Plan

Since the PDF Component test paper loads so fast so i set the `isBuildingPageImage` to be true to show the UI. And verify it works in Prod too.

## Output / Screenshots

Local
![image](https://user-images.githubusercontent.com/84343285/186023107-f77c4c20-2bed-4967-82ba-f6350ff4df03.png)

Prod


https://user-images.githubusercontent.com/84343285/186023718-a09c5b11-1e2d-4854-bf53-196ccdc511ce.mov



### A11y

No A11y involvement