### PR TITLE
Add ability to cap zoom % in PDF Component

### DIFF
--- a/ui/library/src/components/ZoomInButton.tsx
+++ b/ui/library/src/components/ZoomInButton.tsx
@@ -2,10 +2,13 @@ import * as React from 'react';
 
 import { ScrollContext } from '../context/ScrollContext';
 import { TransformContext } from '../context/TransformContext';
+import { PercentFormatter } from '../utils/format';
 
 export type Props = {
   children?: React.ReactNode;
 };
+
+const MAX_ZOOM_IN_SCALE = 500;
 
 export const ZoomInButton: React.FunctionComponent<Props> = ({
   children,
@@ -18,8 +21,11 @@ export const ZoomInButton: React.FunctionComponent<Props> = ({
     (event): void => {
       event.preventDefault();
       event.stopPropagation();
-      updateScrollPosition(1 * zoomMultiplier);
-      setScale(scale * zoomMultiplier);
+      const zoomScale = Number(PercentFormatter.format(scale * zoomMultiplier).replace('%', ''));
+      if (zoomScale <= MAX_ZOOM_IN_SCALE) {
+        updateScrollPosition(1 * zoomMultiplier);
+        setScale(scale * zoomMultiplier);
+      }
     },
     [scale, zoomMultiplier, updateScrollPosition]
   );

--- a/ui/library/src/components/ZoomOutButton.tsx
+++ b/ui/library/src/components/ZoomOutButton.tsx
@@ -2,10 +2,13 @@ import * as React from 'react';
 
 import { ScrollContext } from '../context/ScrollContext';
 import { TransformContext } from '../context/TransformContext';
+import { PercentFormatter } from '../utils/format';
 
 export type Props = {
   children?: React.ReactNode;
 };
+
+const MIN_ZOOM_OUT_SCALE = 25;
 
 export const ZoomOutButton: React.FunctionComponent = ({ children, ...extraProps }: Props) => {
   const { scale, setScale, zoomMultiplier } = React.useContext(TransformContext);
@@ -15,8 +18,11 @@ export const ZoomOutButton: React.FunctionComponent = ({ children, ...extraProps
     (event): void => {
       event.preventDefault();
       event.stopPropagation();
-      updateScrollPosition(1 / zoomMultiplier);
-      setScale(scale / zoomMultiplier);
+      const zoomScale = Number(PercentFormatter.format(scale / zoomMultiplier).replace('%', ''));
+      if (zoomScale >= MIN_ZOOM_OUT_SCALE) {
+        updateScrollPosition(1 / zoomMultiplier);
+        setScale(scale / zoomMultiplier);
+      }
     },
     [scale, zoomMultiplier, updateScrollPosition]
   );

--- a/ui/library/src/utils/format.ts
+++ b/ui/library/src/utils/format.ts
@@ -1,0 +1,4 @@
+export const PercentFormatter = new Intl.NumberFormat('en-US', {
+  style: 'percent',
+  maximumSignificantDigits: 3,
+});


### PR DESCRIPTION
## Description

Ref: https://github.com/allenai/scholar/issues/33320

right now our zoom % can be 1.9% or 1,000,000%. This PR adding a threshold so thats our zoom % wont go beyond that for both in and out.

## Reviewer Instructions

I set the cap limit for zoom out to be 25% and for zoom in to be 500%. User can't click above those.

## Testing Plan

Verify if i cant go below 25% or above 500%. Other than that yarn test, lint, format.

## Output / Screenshots

Before

https://user-images.githubusercontent.com/84343285/186496354-1f6ce24b-63fb-41d6-a446-b091fc2ba1a8.mov



After

https://user-images.githubusercontent.com/84343285/186496149-dcf697f7-39a5-4ffa-85d1-4f913662b680.mov




### A11y
Not involved