### PR TITLE
Avoid Header Collapses when user clicks on TOC Part1

### DIFF
--- a/ui/library/src/context/ScrollContext.ts
+++ b/ui/library/src/context/ScrollContext.ts
@@ -28,8 +28,10 @@ export interface IScrollContext {
   setScrollThreshold: (scrollThreshold: Nullable<number>) => void;
   scrollToPage: (pageNumber: PageNumber) => void;
   updateScrollPosition: (zoomMultiplier: number) => void;
+  setIsOutlineGetClicked: (isOutlineGetClicked: boolean) => void;
   scrollThresholdReachedInDirection: Nullable<ScrollDirection>;
   isAtTop: Nullable<boolean>;
+  isOutlineGetClicked: Nullable<boolean>;
 }
 
 const DEFAULT_CONTEXT: IScrollContext = {
@@ -62,8 +64,12 @@ const DEFAULT_CONTEXT: IScrollContext = {
   updateScrollPosition: zoomMultiplier => {
     logProviderWarning(`updateScrollPosition(${JSON.stringify(zoomMultiplier)})`, 'ScrollContext');
   },
+  setIsOutlineGetClicked: opts => {
+    logProviderWarning(`setIsOutlineGetClicked(${JSON.stringify(opts)})`, 'ScrollContext');
+  },
   scrollThresholdReachedInDirection: null,
   isAtTop: null,
+  isOutlineGetClicked: null,
 };
 
 export const ScrollContext = React.createContext<IScrollContext>(DEFAULT_CONTEXT);
@@ -78,6 +84,7 @@ export function useScrollContextProps(): IScrollContext {
   const [scrollThresholdReachedInDirection, setScrollThresholdReachedInDirection] =
     React.useState<Nullable<ScrollDirection>>(null);
   const [isAtTop, setIsAtTop] = React.useState<Nullable<boolean>>(null);
+  const [isOutlineGetClicked, setIsOutlineGetClicked] = React.useState<Nullable<boolean>>(null);
 
   React.useEffect(() => {
     const scrollElem = scrollRoot || document.documentElement;
@@ -133,6 +140,7 @@ export function useScrollContextProps(): IScrollContext {
   );
 
   const scrollToOutlineTarget = React.useCallback((dest: NodeDestination): void => {
+    setIsOutlineGetClicked(true);
     document
       .querySelector(`[data-outline-target-dest="${dest}"]`)
       ?.scrollIntoView({ behavior: 'smooth' });
@@ -239,7 +247,9 @@ export function useScrollContextProps(): IScrollContext {
     setScrollThreshold,
     scrollToPage,
     updateScrollPosition,
+    setIsOutlineGetClicked,
     scrollThresholdReachedInDirection,
     isAtTop,
+    isOutlineGetClicked,
   };
 }

--- a/ui/library/src/context/ScrollContext.ts
+++ b/ui/library/src/context/ScrollContext.ts
@@ -28,10 +28,10 @@ export interface IScrollContext {
   setScrollThreshold: (scrollThreshold: Nullable<number>) => void;
   scrollToPage: (pageNumber: PageNumber) => void;
   updateScrollPosition: (zoomMultiplier: number) => void;
-  setIsOutlineGetClicked: (isOutlineGetClicked: boolean) => void;
+  setIsOutlineClicked: (isOutlineGetClicked: boolean) => void;
   scrollThresholdReachedInDirection: Nullable<ScrollDirection>;
   isAtTop: Nullable<boolean>;
-  isOutlineGetClicked: Nullable<boolean>;
+  isOutlineClicked: Nullable<boolean>;
 }
 
 const DEFAULT_CONTEXT: IScrollContext = {
@@ -64,12 +64,12 @@ const DEFAULT_CONTEXT: IScrollContext = {
   updateScrollPosition: zoomMultiplier => {
     logProviderWarning(`updateScrollPosition(${JSON.stringify(zoomMultiplier)})`, 'ScrollContext');
   },
-  setIsOutlineGetClicked: opts => {
+  setIsOutlineClicked: opts => {
     logProviderWarning(`setIsOutlineGetClicked(${JSON.stringify(opts)})`, 'ScrollContext');
   },
   scrollThresholdReachedInDirection: null,
   isAtTop: null,
-  isOutlineGetClicked: null,
+  isOutlineClicked: null,
 };
 
 export const ScrollContext = React.createContext<IScrollContext>(DEFAULT_CONTEXT);
@@ -84,7 +84,7 @@ export function useScrollContextProps(): IScrollContext {
   const [scrollThresholdReachedInDirection, setScrollThresholdReachedInDirection] =
     React.useState<Nullable<ScrollDirection>>(null);
   const [isAtTop, setIsAtTop] = React.useState<Nullable<boolean>>(null);
-  const [isOutlineGetClicked, setIsOutlineGetClicked] = React.useState<Nullable<boolean>>(null);
+  const [isOutlineClicked, setIsOutlineClicked] = React.useState<Nullable<boolean>>(null);
 
   React.useEffect(() => {
     const scrollElem = scrollRoot || document.documentElement;
@@ -140,7 +140,7 @@ export function useScrollContextProps(): IScrollContext {
   );
 
   const scrollToOutlineTarget = React.useCallback((dest: NodeDestination): void => {
-    setIsOutlineGetClicked(true);
+    setIsOutlineClicked(true);
     document
       .querySelector(`[data-outline-target-dest="${dest}"]`)
       ?.scrollIntoView({ behavior: 'smooth' });
@@ -247,9 +247,9 @@ export function useScrollContextProps(): IScrollContext {
     setScrollThreshold,
     scrollToPage,
     updateScrollPosition,
-    setIsOutlineGetClicked,
+    setIsOutlineClicked,
     scrollThresholdReachedInDirection,
     isAtTop,
-    isOutlineGetClicked,
+    isOutlineClicked,
   };
 }


### PR DESCRIPTION
## Description

Ref: https://github.com/allenai/scholar/issues/33326

On Bug Bash we noticed that when we click on any section of TOC. It will scroll to the position and at the same time collapse header which is not desirable. This PR addresses this issue.

## Reviewer Instructions

I created a useState called `IsOutlineGetClicked` and when it get clicked this will set to true (this happens inside `ScrollContext` since when we click on Outline it will call `scrollToOutlineTarget` in `ScrollContext`). But on user mouse wheel in general it will set to false so the header will collapse like normal (scroll doesn't work since it not count toward user actually scroll).

## Testing Plan

To verify it works in Prod. In ReaderHeader i specifically add code like below to verify it works. Other than that yarn format, lint, test.

**ReaderHeader**
![image](https://user-images.githubusercontent.com/84343285/186517862-12871e7b-f5a5-4e4f-96cc-0061e6794bb7.png)
**Reader**
![image](https://user-images.githubusercontent.com/84343285/186517911-f25bd2a0-d39f-4b9c-895c-1bc2a95e26a7.png)


## Output / Screenshots

https://user-images.githubusercontent.com/84343285/186518383-3c441b23-33a1-44ad-b205-32c5b887a9e0.mov

### A11y

No A11y involvement
