### PR TITLE
Create pull request template for PDF Component library

### DIFF
--- a/.github/workflows/pull_request_template.md
+++ b/.github/workflows/pull_request_template.md
@@ -1,0 +1,25 @@
+## Description
+
+Describe the change and its purpose. Include a ticket if applicable.
+
+## Reviewer Instructions
+
+Anything a review needs to know about this PR to help them give better feedback. Are there specific questions you have? Are there areas you are unsure of? Does this come from or relate to another part of the codebase?
+
+## Testing Plan
+
+Describe what you did to test the change.
+
+## Output / Screenshots
+
+### Before
+
+What did it look like before?
+
+### After
+
+What will it look like after merging?
+
+### A11y
+
+How do keyboard navigation and screen readers work with this PR?


### PR DESCRIPTION
Since the PDF component library doesn't have a pull request template like scholar repo so I taken the liberty to do this and will set up it after it get merged into the code base.