### PR TITLE
Fix Blurry Issue on Semantic Reader_Part1

### DIFF
--- a/ui/library/src/context/ContextProvider.tsx
+++ b/ui/library/src/context/ContextProvider.tsx
@@ -17,9 +17,8 @@ export const ContextProvider: React.FunctionComponent<Props> = ({ children }: Pr
   const scrollProps = useScrollContextProps();
   const pageRenderProps = usePageRenderContextProps({
     pdfDocProxy: documentProps.pdfDocProxy,
+    pixelRatio: transformProps.pixelRatio,
     scale: transformProps.scale,
-    rotation: transformProps.rotation,
-    zoomMultiplier: transformProps.zoomMultiplier,
     visiblePageRatios: scrollProps.visiblePageRatios,
   });
 

--- a/ui/library/src/context/PageRenderContext.ts
+++ b/ui/library/src/context/PageRenderContext.ts
@@ -4,7 +4,6 @@ import { pdfjs } from 'react-pdf';
 import { PageNumber } from '../components/types/page';
 import { Nullable } from '../components/types/utils';
 import { logProviderWarning } from '../utils/provider';
-import { PageRotation } from '../utils/rotate';
 
 export type RenderState = {
   promise: Promise<string>;
@@ -38,15 +37,13 @@ export const PageRenderContext = React.createContext<IPageRenderContext>({
 
 export function usePageRenderContextProps({
   pdfDocProxy,
+  pixelRatio,
   scale,
-  rotation,
-  zoomMultiplier,
   visiblePageRatios,
 }: {
   pdfDocProxy?: pdfjs.PDFDocumentProxy;
+  pixelRatio: number;
   scale: number;
-  rotation: PageRotation;
-  zoomMultiplier: number;
   visiblePageRatios: Map<number, number>;
 }): IPageRenderContext {
   const [pageRenderStates, _setPageRenderStates] = React.useState<PageNumberToRenderStateMap>(
@@ -119,9 +116,8 @@ export function usePageRenderContextProps({
       const promise = buildPageObjectURL({
         pageNumber,
         pdfDocProxy,
+        pixelRatio,
         scale,
-        rotation,
-        zoomMultiplier,
       });
       const renderState: RenderState = {
         promise,
@@ -139,7 +135,7 @@ export function usePageRenderContextProps({
       setPageRenderStates(newPageRenderStates);
       return promise;
     },
-    [pageRenderStates, pdfDocProxy, scale, rotation, zoomMultiplier]
+    [pageRenderStates, pdfDocProxy, scale]
   );
 
   React.useEffect(() => {
@@ -159,22 +155,22 @@ export function usePageRenderContextProps({
   };
 }
 
+// This boost causes the rendered image to be scaled up by this amount
+const SCALE_BOOST = 2;
+
 // Generate an object url for a given page, rendered in a shared canvas
 async function buildPageObjectURL({
   pageNumber,
   pdfDocProxy,
+  pixelRatio = window.devicePixelRatio || 1,
   scale = 1,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  rotation = PageRotation.Rotate0,
-  zoomMultiplier = 1.2,
   imageType = 'image/png',
   imageQuality = 1.0,
 }: {
   pageNumber: number;
   pdfDocProxy: pdfjs.PDFDocumentProxy;
+  pixelRatio?: number;
   scale?: number;
-  rotation?: PageRotation;
-  zoomMultiplier?: number;
   imageType?: string;
   imageQuality?: number;
 }): Promise<string> {
@@ -182,7 +178,7 @@ async function buildPageObjectURL({
 
   const blob: Nullable<Blob> = await useRenderCanvas(async canvas => {
     // Render page in a canvas
-    const viewport = pageProxy.getViewport({ scale: scale * zoomMultiplier * devicePixelRatio });
+    const viewport = pageProxy.getViewport({ scale: scale * pixelRatio * SCALE_BOOST });
     canvas.height = viewport.height;
     canvas.width = viewport.width;
     const canvasContext = canvas.getContext('2d');

--- a/ui/library/src/context/TransformContext.ts
+++ b/ui/library/src/context/TransformContext.ts
@@ -4,18 +4,24 @@ import { logProviderWarning } from '../utils/provider';
 import { PageRotation } from '../utils/rotate';
 
 export interface ITransformContext {
+  pixelRatio: number;
   rotation: PageRotation;
   scale: number;
   zoomMultiplier: number;
+  setPixelRatio: (devicePixelRatio: number) => void;
   setRotation: (rotation: PageRotation) => void;
   setScale: (scale: number) => void;
   setZoomMultiplier: (zoom: number) => void;
 }
 
 export const TransformContext = React.createContext<ITransformContext>({
+  pixelRatio: window.devicePixelRatio || 1,
   rotation: PageRotation.Rotate0,
   scale: 1,
   zoomMultiplier: 1.2,
+  setPixelRatio: pixelRatio => {
+    logProviderWarning(`setPixelRatio(${pixelRatio})`, 'TransformContext');
+  },
   setRotation: rotation => {
     logProviderWarning(`setRotation(${rotation})`, 'TransformContext');
   },
@@ -28,13 +34,16 @@ export const TransformContext = React.createContext<ITransformContext>({
 });
 
 export function useTransformContextProps(): ITransformContext {
+  const [pixelRatio, setPixelRatio] = React.useState<number>(window.devicePixelRatio || 1);
   const [rotation, setRotation] = React.useState<PageRotation>(PageRotation.Rotate0);
   const [scale, setScale] = React.useState<number>(1.0);
   const [zoomMultiplier, setZoomMultiplier] = React.useState<number>(1.2);
 
   return {
+    pixelRatio,
     rotation,
     scale,
+    setPixelRatio,
     setRotation,
     setScale,
     setZoomMultiplier,

--- a/ui/library/test/context/TransformContext.test.tsx
+++ b/ui/library/test/context/TransformContext.test.tsx
@@ -23,6 +23,7 @@ describe('<TransformContext/>', () => {
     return <TransformContext.Provider value={contextProps}>{children}</TransformContext.Provider>;
   }
 
+  let _setPixelRatio: (devicePixelRatio: number) => void;
   let _setRotation: (rotation: PageRotation) => void;
   let _setScale: (scale: number) => void;
   let _setZoomMultiplier: (zoom: number) => void;
@@ -32,13 +33,23 @@ describe('<TransformContext/>', () => {
       <UseContext>
         <TransformContext.Consumer>
           {(args: ITransformContext) => {
-            const { rotation, scale, zoomMultiplier, setRotation, setScale, setZoomMultiplier } =
-              args;
+            const {
+              pixelRatio,
+              rotation,
+              scale,
+              zoomMultiplier,
+              setPixelRatio,
+              setRotation,
+              setScale,
+              setZoomMultiplier,
+            } = args;
+            _setPixelRatio = setPixelRatio;
             _setRotation = setRotation;
             _setScale = setScale;
             _setZoomMultiplier = setZoomMultiplier;
             return (
               <div>
+                <div className="pixelRatio">{pixelRatio}</div>
                 <div className="scale">{scale}</div>
                 <div className="rotation">{rotation}</div>
                 <div className="zoom">{zoomMultiplier}</div>
@@ -54,6 +65,10 @@ describe('<TransformContext/>', () => {
     wrapper.unmount();
   });
 
+  it('provides a default pixelRatio', () => {
+    expectTextFromClassName('pixelRatio', 1);
+  });
+
   it('provides a default rotation', () => {
     expectTextFromClassName('rotation', 0);
   });
@@ -64,6 +79,14 @@ describe('<TransformContext/>', () => {
 
   it('provides a default zoom multiplier', () => {
     expectTextFromClassName('zoom', 1.2);
+  });
+
+  it('provides a function to set pixelRatio', () => {
+    expectTextFromClassName('pixelRatio', 1);
+
+    _setPixelRatio(2);
+
+    expectTextFromClassName('pixelRatio', 2);
   });
 
   it('provides a function to set rotation', () => {


### PR DESCRIPTION
## Description

Recently our user noticed that the image on Semantic Reader is really blurry. This PR addresses this

## Reviewer Instructions

First thing is to eliminate zoomMultiplier when it comes to canvas size because zoom multiplier is just how fast the zoom grow (like 100-120 or 120-140) so we dont need that and also rotation. Adding another SCALE_BOOST variable with default value to be 2 to increase the sharpness of our image on canvas overall (cant go more than 2 due to Safari will crash due to the way they render their canvas). The next PR will add a react.useEffect to listen for devicePixelRatio change and also scale change to repopulate the imageUrl again.

## Testing Plan

Verify if the image display is more crisp compare to previous. Other than that yarn lint, format, test

## Output / Screenshots
Look at how sharp the image now compare to previous
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/84343285/186973416-03062e90-c2fc-42ff-a953-10afc2dd3a65.png">

Since i dont have my monitor now i change the scale of my screen to simulate that
<img width="2045" alt="image" src="https://user-images.githubusercontent.com/84343285/186974754-114b77f0-a3dc-4deb-befa-6a6c4d4ef849.png">



### A11y

No A11y involvement.
