### PR TITLE
Refactor PDF Component Layout  to be single scrollbar 

### DIFF
--- a/ui/demo/components/Reader.tsx
+++ b/ui/demo/components/Reader.tsx
@@ -52,8 +52,8 @@ export const Reader: React.FunctionComponent<RouteComponentProps> = () => {
   }, [pageDimensions]);
 
   React.useEffect(() => {
-    setScrollRoot(pdfScrollableRef.current || null);
-  }, [pdfScrollableRef]);
+    setScrollRoot(null);
+  }, []);
 
   // Attaches annotation data to paper
   React.useEffect(() => {

--- a/ui/demo/less/reader.less
+++ b/ui/demo/less/reader.less
@@ -3,10 +3,6 @@
   display: inline;
 }
 
-.reader__header {
-  grid-area: header;
-}
-
 .reader__main {
   background-color: @grey;
   display: flex;
@@ -36,10 +32,14 @@
   }
 }
 
-.reader__header{
+.reader__header {
+  background-color: @pdflib-page-background;
   padding: 20px;
+  position: sticky;
   text-align: center;
-
+  top: 0;
+  z-index: @z-index-header;
+  
   .header-control {
     display: inline-block;
     margin-top: 10px;

--- a/ui/demo/less/reader.less
+++ b/ui/demo/less/reader.less
@@ -18,7 +18,9 @@ body {
 }
 
 .reader__main {
+  background-color: @grey;
   grid-area: main;
+  overflow: auto;
   position: relative;
 }
 
@@ -27,7 +29,6 @@ body {
   flex-direction: column;
   align-items: center;
   background-color: @grey;
-  overflow: scroll;
   height: 100%;
   position: relative;
 }

--- a/ui/demo/less/reader.less
+++ b/ui/demo/less/reader.less
@@ -1,16 +1,6 @@
-body {
-  overflow: hidden;
-  position: fixed;
-}
 
 .reader__container {
-  display: grid;
-  grid-template-rows: 100px minmax(0, 1fr);
-  grid-template-areas:
-    "header"
-    "main";
-  height: 100vh;
-  width: 100vw;
+  display: inline;
 }
 
 .reader__header {
@@ -19,7 +9,9 @@ body {
 
 .reader__main {
   background-color: @grey;
-  grid-area: main;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
   overflow: auto;
   position: relative;
 }

--- a/ui/demo/less/reader.less
+++ b/ui/demo/less/reader.less
@@ -58,6 +58,7 @@
   z-index: @z-index-outline;
 }
 
+// HACK: -100px is accommodate for the header when we do outline scrolling
 .reader__page__outline-target {
   transform: translateY(-100px);
 }

--- a/ui/demo/less/reader.less
+++ b/ui/demo/less/reader.less
@@ -58,6 +58,10 @@
   z-index: @z-index-outline;
 }
 
+.reader__page__outline-target {
+  transform: translateY(-100px);
+}
+
 .reader__popover__citation {
   min-width: 270px;
   max-width: 310px;

--- a/ui/demo/less/reader.less
+++ b/ui/demo/less/reader.less
@@ -52,7 +52,10 @@
 }
 
 .reader__outline-drawer {
-  position: absolute;
+  left: 0;
+  position: fixed;
+  top: 100px;
+  z-index: @z-index-outline;
 }
 
 .reader__popover__citation {

--- a/ui/demo/less/reader.less
+++ b/ui/demo/less/reader.less
@@ -1,14 +1,8 @@
-
-.reader__container {
-  display: inline;
-}
-
 .reader__main {
   background-color: @grey;
   display: flex;
   flex-direction: row;
   justify-content: center;
-  overflow: auto;
   position: relative;
 }
 

--- a/ui/library/less/zindex.less
+++ b/ui/library/less/zindex.less
@@ -1,1 +1,2 @@
 @z-index-bounding-box-overlay: 1;
+@z-index-header: 999;

--- a/ui/library/less/zindex.less
+++ b/ui/library/less/zindex.less
@@ -1,2 +1,3 @@
 @z-index-bounding-box-overlay: 1;
 @z-index-header: 999;
+@z-index-outline: 500;

--- a/ui/library/less/zindex.less
+++ b/ui/library/less/zindex.less
@@ -1,3 +1,3 @@
 @z-index-bounding-box-overlay: 1;
-@z-index-header: 999;
 @z-index-outline: 500;
+@z-index-header: 999;


### PR DESCRIPTION
## Description

Ref: https://github.com/allenai/scholar/issues/33432

The PDF Component library still has double scroll bar. This PR addresses it. 

## Reviewer Instructions

Eventually we will eliminate the feature flag and make our single scroll bar becomes primary. To keep it consistent with Prod we would want to make sure our component library will be like that so we can have a consistency between two environment for a better development time too. I got rid of the double scrollbar and make it single to look like Prod.

## Testing Plan

Manually makes sure after layout changes for Demo App everything works.

## Output / Screenshots


https://user-images.githubusercontent.com/84343285/187794343-e31ef194-6041-4833-b2de-4bfc636802ac.mov


### A11y

No A11y involvement.
