### PR TITLE
show text layer until background image is finished loading

### DIFF
--- a/ui/library/less/styles.less
+++ b/ui/library/less/styles.less
@@ -69,6 +69,12 @@
   width: 125px;
 }
 
+.reader__page--has-page-image {
+  .textLayer {
+    color: transparent;
+  }
+}
+
 .reader__page-highlight-overlay {
   pointer-events: none;
   position: absolute;

--- a/ui/library/less/text-layer.less
+++ b/ui/library/less/text-layer.less
@@ -18,7 +18,7 @@
   
   .textLayer span,
   .textLayer br {
-    color: transparent;
+    // color: transparent;   // we are removing this because we show the text layer until the background image is rendered
     position: absolute;
     white-space: pre;
     cursor: text;


### PR DESCRIPTION
## Description

Previously, we showed the TextLayer until the background image was loaded. Upgrading to react-pdf v6 broke this so that the textLayer was always transparent. This PR changes that so that the textLayer is shown until the background image is loaded. 