### PR TITLE
Adding Thumbnails into PDF Component

### DIFF
--- a/ui/demo/components/Header.tsx
+++ b/ui/demo/components/Header.tsx
@@ -24,12 +24,17 @@ export const Header: React.FunctionComponent<Props> = ({ pdfUrl }: Props) => {
     setIsShowingHighlightOverlay,
     setIsShowingOutline,
     setIsShowingTextHighlight,
+    setIsShowingThumbnail,
   } = React.useContext(UiContext);
   const { rotation, setRotation } = React.useContext(TransformContext);
   const { isShowingNoteTaking, setIsShowingNoteTaking } = React.useContext(DemoHeaderContext);
 
   const handleShowOutline = React.useCallback(() => {
     setIsShowingOutline(true);
+  }, []);
+
+  const handleShowThumbnail = React.useCallback(() => {
+    setIsShowingThumbnail(true);
   }, []);
 
   const handleRotateCW = React.useCallback(() => {
@@ -75,6 +80,9 @@ export const Header: React.FunctionComponent<Props> = ({ pdfUrl }: Props) => {
       </div>
       <div className="header-control">
         <a onClick={handleShowOutline}>Outline</a>
+      </div>
+      <div className="header-control">
+        <a onClick={handleShowThumbnail}>Thumbnail</a>
       </div>
       <div className={classnames('header-control', { 'is-selected': isShowingHighlightOverlay })}>
         <a onClick={handleToggleHighlightOverlay}>Highlight Overlay</a>

--- a/ui/demo/components/Reader.tsx
+++ b/ui/demo/components/Reader.tsx
@@ -19,6 +19,7 @@ import { NoteTakingDemo } from './NoteTakingDemo';
 import { Outline } from './Outline';
 import { ScrollToDemo } from './ScrollToDemo';
 import { TextHighlightDemo } from './TextHighlightDemo';
+import { Thumbnail } from './Thumbnail';
 
 export const Reader: React.FunctionComponent<RouteComponentProps> = () => {
   const { pageDimensions, numPages } = React.useContext(DocumentContext);
@@ -73,6 +74,7 @@ export const Reader: React.FunctionComponent<RouteComponentProps> = () => {
             <Header pdfUrl={samplePdfUrl} />
             <DocumentWrapper className="reader__main" file={samplePdfUrl} inputRef={pdfContentRef}>
               <Outline parentRef={pdfContentRef} />
+              <Thumbnail parentRef={pdfContentRef} />
               <div className="reader__page-list" ref={pdfScrollableRef}>
                 {Array.from({ length: numPages }).map((_, i) => (
                   <PageWrapper key={i} pageIndex={i}>

--- a/ui/demo/components/Thumbnail.tsx
+++ b/ui/demo/components/Thumbnail.tsx
@@ -1,0 +1,31 @@
+import { ThumbnailList, UiContext } from '@allenai/pdf-components';
+import { Drawer } from 'antd';
+import * as React from 'react';
+
+type Props = {
+  parentRef: React.RefObject<HTMLDivElement>;
+};
+
+export const Thumbnail: React.FunctionComponent<Props> = ({ parentRef }: Props) => {
+  const { isShowingThumbnail, setIsShowingThumbnail } = React.useContext(UiContext);
+
+  const handleHideThumbnail = React.useCallback(() => {
+    setIsShowingThumbnail(false);
+  }, []);
+
+  return (
+    <Drawer
+      title="Thumbnail"
+      placement="left"
+      visible={isShowingThumbnail}
+      mask={false}
+      onClose={handleHideThumbnail}
+      // Passing this ref mounts the drawer "inside" the grid content area
+      // instead of using the entire browser height.
+      //@ts-ignore there's something wonky with the types here
+      getContainer={parentRef.current}
+      className="reader__outline-drawer">
+      <ThumbnailList />
+    </Drawer>
+  );
+};

--- a/ui/demo/less/reader.less
+++ b/ui/demo/less/reader.less
@@ -72,7 +72,7 @@
   }
 }
 
-.reader__thumbnail-list__list {
+.reader__thumbnail-list {
   display: flex;
   flex-direction: column;
   padding-left: 0;
@@ -90,7 +90,7 @@
   transition: opacity 400ms ease-in-out;
   width: 100%;
 
-  &.reader__thumbnail--no-page-image {
+  &.reader__thumbnail--no-image {
     background-color: rgba(0, 0, 0, .1);
   }
 
@@ -99,7 +99,7 @@
     transition-duration: 75ms;
   }
 
-  &.reader__thumbnail--has-page-visible {
+  &.reader__thumbnail--is-visible {
     opacity: 1;
     transition-duration: 200ms;
   }

--- a/ui/demo/less/reader.less
+++ b/ui/demo/less/reader.less
@@ -72,3 +72,36 @@
   }
 }
 
+.reader__thumbnail-list__list {
+  display: flex;
+  flex-direction: column;
+  padding-left: 0;
+}
+
+.reader__thumbnail-list__item:nth-of-type(n + 1) {
+  margin-top: 16px;
+}
+
+.reader__thumbnail {
+  box-shadow: 2px 2px 8px rgba(0, 0, 0, .8);
+  cursor: pointer;
+  min-height: 250px;
+  opacity: .5;
+  transition: opacity 400ms ease-in-out;
+  width: 100%;
+
+  &.reader__thumbnail--no-page-image {
+    background-color: rgba(0, 0, 0, .1);
+  }
+
+  &:hover {
+    opacity: .75;
+    transition-duration: 75ms;
+  }
+
+  &.reader__thumbnail--has-page-visible {
+    opacity: 1;
+    transition-duration: 200ms;
+  }
+}
+

--- a/ui/library/index.ts
+++ b/ui/library/index.ts
@@ -16,6 +16,8 @@ import { OutlineItem } from './src/components/outline/OutlineItem';
 import { Overlay, Props as OverlayProps } from './src/components/Overlay';
 import { PageNumberControl } from './src/components/PageNumberControl';
 import { PageProps, PageWrapper, Props as PageWrapperProps } from './src/components/PageWrapper';
+import { Thumbnail } from './src/components/thumbnails/Thumbnail';
+import { ThumbnailList } from './src/components/thumbnails/ThumbnailList';
 import {
   BoundingBox as BoundingBoxType,
   Dimensions,
@@ -101,6 +103,8 @@ export {
   ScrollContext,
   scrollToId,
   scrollToPdfPageIndex,
+  Thumbnail,
+  ThumbnailList,
   TransformContext,
   UiContext,
   ZoomInButton,
@@ -132,6 +136,8 @@ export default {
   scaleRawBoundingBox,
   scrollToId,
   scrollToPdfPageIndex,
+  Thumbnail,
+  ThumbnailList,
   ScrollContext,
   TransformContext,
   UiContext,

--- a/ui/library/less/styles.less
+++ b/ui/library/less/styles.less
@@ -120,3 +120,15 @@
 .reader__page-number-control__current-page::-webkit-outer-spin-button { 
 	-webkit-appearance: none;
 }
+
+.reader__thumbnail-list__list {
+  list-style: none;
+}
+
+.reader__thumbnail {
+  display: inline-block;
+}
+
+.reader__thumbnail__image {
+  width: 100%;
+}

--- a/ui/library/less/styles.less
+++ b/ui/library/less/styles.less
@@ -152,7 +152,7 @@
   display: inline-block;
 }
 
-.reader__thumbnail__image {
+.reader__thumbnail-image {
   width: 100%;
 } 
 

--- a/ui/library/less/styles.less
+++ b/ui/library/less/styles.less
@@ -121,7 +121,30 @@
 	-webkit-appearance: none;
 }
 
-.reader__thumbnail-list__list {
+.reader__thumbnail {
+  box-shadow: 2px 2px 8px rgba(0, 0, 0, .8);
+  cursor: pointer;
+  min-height: 250px;
+  opacity: .5;
+  transition: opacity 400ms ease-in-out;
+  width: 100%;
+
+  &.reader__thumbnail--no-image {
+    background-color: rgba(0, 0, 0, .1);
+  }
+
+  &:hover {
+    opacity: .75;
+    transition-duration: 75ms;
+  }
+
+  &.reader__thumbnail--is-visible {
+    opacity: 1;
+    transition-duration: 200ms;
+  }
+}
+
+.reader__thumbnail-list {
   list-style: none;
 }
 
@@ -131,4 +154,8 @@
 
 .reader__thumbnail__image {
   width: 100%;
+} 
+
+.reader__thumbnail-list__item:nth-of-type(n + 1) {
+  margin-top: 16px;
 }

--- a/ui/library/src/components/thumbnails/Thumbnail.tsx
+++ b/ui/library/src/components/thumbnails/Thumbnail.tsx
@@ -9,14 +9,14 @@ type Props = {
 };
 
 export const Thumbnail: React.FunctionComponent<Props> = ({ pageNumber }: Props) => {
-  const { buildObjectURLForPage, getObjectURLForPage } = React.useContext(PageRenderContext);
+  const { pageRenderStates, buildObjectURLForPage, getObjectURLForPage } = React.useContext(PageRenderContext);
   const { isPageVisible, scrollToPage } = React.useContext(ScrollContext);
   const objectURL = getObjectURLForPage({ pageNumber });
   const hasPageVisible = isPageVisible({ pageNumber });
 
   React.useEffect(() => {
     buildObjectURLForPage({ pageNumber });
-  }, [pageNumber]);
+  }, [pageNumber, pageRenderStates]);
 
   const onClick = React.useCallback(
     event => {

--- a/ui/library/src/components/thumbnails/Thumbnail.tsx
+++ b/ui/library/src/components/thumbnails/Thumbnail.tsx
@@ -9,7 +9,8 @@ type Props = {
 };
 
 export const Thumbnail: React.FunctionComponent<Props> = ({ pageNumber }: Props) => {
-  const { pageRenderStates, buildObjectURLForPage, getObjectURLForPage } = React.useContext(PageRenderContext);
+  const { pageRenderStates, buildObjectURLForPage, getObjectURLForPage } =
+    React.useContext(PageRenderContext);
   const { isPageVisible, scrollToPage } = React.useContext(ScrollContext);
   const objectURL = getObjectURLForPage({ pageNumber });
   const hasPageVisible = isPageVisible({ pageNumber });

--- a/ui/library/src/components/thumbnails/Thumbnail.tsx
+++ b/ui/library/src/components/thumbnails/Thumbnail.tsx
@@ -52,7 +52,7 @@ export const Thumbnail: React.FunctionComponent<Props> = ({ pageNumber }: Props)
         { 'reader__thumbnail--is-visible': isThumbnailVisible }
       )}
       data-page-number={pageNumber}>
-      <img className="reader__thumbnail__image" src={objectURL || undefined} />
+      {!!objectURL && <img className="reader__thumbnail__image" src={objectURL} />}
     </a>
   );
 };

--- a/ui/library/src/components/thumbnails/Thumbnail.tsx
+++ b/ui/library/src/components/thumbnails/Thumbnail.tsx
@@ -1,0 +1,44 @@
+import classnames from 'classnames';
+import * as React from 'react';
+
+import { PageRenderContext } from '../../context/PageRenderContext';
+import { ScrollContext } from '../../context/ScrollContext';
+
+type Props = {
+  pageNumber: number;
+};
+
+export const Thumbnail: React.FunctionComponent<Props> = ({ pageNumber }: Props) => {
+  const { buildObjectURLForPage, getObjectURLForPage } = React.useContext(PageRenderContext);
+  const { isPageVisible, scrollToPage } = React.useContext(ScrollContext);
+  const objectURL = getObjectURLForPage({ pageNumber });
+  const hasPageVisible = isPageVisible({ pageNumber });
+
+  React.useEffect(() => {
+    buildObjectURLForPage({ pageNumber });
+  }, [pageNumber]);
+
+  const onClick = React.useCallback(
+    event => {
+      event.preventDefault();
+      scrollToPage({ pageNumber });
+    },
+    [pageNumber, scrollToPage]
+  );
+
+  return (
+    <a
+      aria-label={`scroll to page ${pageNumber}`}
+      onClick={onClick}
+      className={classnames(
+        'reader__thumbnail',
+        { 'reader__thumbnail--has-page-image': objectURL },
+        { 'reader__thumbnail--no-page-image': !objectURL },
+        { 'reader__thumbnail--has-page-visible': hasPageVisible },
+        { 'reader__thumbnail--no-page-visible': !hasPageVisible }
+      )}
+      data-page-number={pageNumber}>
+      <img className="reader__thumbnail__image" src={objectURL || undefined} />
+    </a>
+  );
+};

--- a/ui/library/src/components/thumbnails/Thumbnail.tsx
+++ b/ui/library/src/components/thumbnails/Thumbnail.tsx
@@ -11,12 +11,9 @@ type Props = {
 };
 
 export const Thumbnail: React.FunctionComponent<Props> = ({ pageNumber }: Props) => {
-  const { pageRenderStates, buildObjectURLForPage, getObjectURLForPage } =
-    React.useContext(PageRenderContext);
+  const { buildObjectURLForPage, getObjectURLForPage } = React.useContext(PageRenderContext);
   const { isPageVisible, scrollToPage, visiblePageRatios } = React.useContext(ScrollContext);
-
   const [maxVisiblePageNumber, setMaxVisiblePageNumber] = React.useState<Nullable<string>>(null);
-
   const objectURL = getObjectURLForPage({ pageNumber });
 
   React.useEffect(() => {
@@ -28,14 +25,14 @@ export const Thumbnail: React.FunctionComponent<Props> = ({ pageNumber }: Props)
     }
   }, [visiblePageRatios]);
 
-  const hasPageVisible =
+  const isThumbnailVisible =
     maxVisiblePageNumber &&
     parseInt(maxVisiblePageNumber) === pageNumber &&
     isPageVisible({ pageNumber });
 
   React.useEffect(() => {
     buildObjectURLForPage({ pageNumber });
-  }, [pageNumber, pageRenderStates]);
+  }, [pageNumber]);
 
   const onClick = React.useCallback(
     event => {
@@ -51,10 +48,8 @@ export const Thumbnail: React.FunctionComponent<Props> = ({ pageNumber }: Props)
       onClick={onClick}
       className={classnames(
         'reader__thumbnail',
-        { 'reader__thumbnail--has-page-image': objectURL },
-        { 'reader__thumbnail--no-page-image': !objectURL },
-        { 'reader__thumbnail--has-page-visible': hasPageVisible },
-        { 'reader__thumbnail--no-page-visible': !hasPageVisible }
+        { 'reader__thumbnail--no-image': !objectURL },
+        { 'reader__thumbnail--is-visible': isThumbnailVisible }
       )}
       data-page-number={pageNumber}>
       <img className="reader__thumbnail__image" src={objectURL || undefined} />

--- a/ui/library/src/components/thumbnails/Thumbnail.tsx
+++ b/ui/library/src/components/thumbnails/Thumbnail.tsx
@@ -3,6 +3,8 @@ import * as React from 'react';
 
 import { PageRenderContext } from '../../context/PageRenderContext';
 import { ScrollContext } from '../../context/ScrollContext';
+import { getMaxVisibleElement } from '../../utils/MaxVisibleElement';
+import { Nullable } from '../types/utils';
 
 type Props = {
   pageNumber: number;
@@ -11,9 +13,25 @@ type Props = {
 export const Thumbnail: React.FunctionComponent<Props> = ({ pageNumber }: Props) => {
   const { pageRenderStates, buildObjectURLForPage, getObjectURLForPage } =
     React.useContext(PageRenderContext);
-  const { isPageVisible, scrollToPage } = React.useContext(ScrollContext);
+  const { isPageVisible, scrollToPage, visiblePageRatios } = React.useContext(ScrollContext);
+
+  const [maxVisiblePageNumber, setMaxVisiblePageNumber] = React.useState<Nullable<string>>(null);
+
   const objectURL = getObjectURLForPage({ pageNumber });
-  const hasPageVisible = isPageVisible({ pageNumber });
+
+  React.useEffect(() => {
+    if (visiblePageRatios.size !== 0) {
+      const max = getMaxVisibleElement(visiblePageRatios);
+      if (max) {
+        setMaxVisiblePageNumber(max.toString());
+      }
+    }
+  }, [visiblePageRatios]);
+
+  const hasPageVisible =
+    maxVisiblePageNumber &&
+    parseInt(maxVisiblePageNumber) === pageNumber &&
+    isPageVisible({ pageNumber });
 
   React.useEffect(() => {
     buildObjectURLForPage({ pageNumber });

--- a/ui/library/src/components/thumbnails/Thumbnail.tsx
+++ b/ui/library/src/components/thumbnails/Thumbnail.tsx
@@ -52,7 +52,7 @@ export const Thumbnail: React.FunctionComponent<Props> = ({ pageNumber }: Props)
         { 'reader__thumbnail--is-visible': isThumbnailVisible }
       )}
       data-page-number={pageNumber}>
-      {!!objectURL && <img className="reader__thumbnail__image" src={objectURL} />}
+      {!!objectURL && <img className="reader__thumbnail-image" src={objectURL} />}
     </a>
   );
 };

--- a/ui/library/src/components/thumbnails/ThumbnailList.tsx
+++ b/ui/library/src/components/thumbnails/ThumbnailList.tsx
@@ -9,8 +9,8 @@ export const ThumbnailList: React.FunctionComponent<Props> = () => {
   const { numPages } = React.useContext(DocumentContext);
 
   return (
-    <div className="reader__thumbnail-list">
-      <ul className="reader__thumbnail-list__list">
+    <div className="reader__thumbnail-list-wrapper">
+      <ul className="reader__thumbnail-list">
         {Array.from({ length: numPages })
           .map((_, i) => i + 1)
           .map(pageNumber => (

--- a/ui/library/src/components/thumbnails/ThumbnailList.tsx
+++ b/ui/library/src/components/thumbnails/ThumbnailList.tsx
@@ -11,13 +11,11 @@ export const ThumbnailList: React.FunctionComponent<Props> = () => {
   return (
     <div className="reader__thumbnail-list-wrapper">
       <ul className="reader__thumbnail-list">
-        {Array.from({ length: numPages })
-          .map((_, i) => i + 1)
-          .map(pageNumber => (
-            <li key={pageNumber} className="reader__thumbnail-list__item">
-              <Thumbnail pageNumber={pageNumber} />
-            </li>
-          ))}
+        {Array.from({ length: numPages }).map((_, pageIndex) => (
+          <li key={pageIndex + 1} className="reader__thumbnail-list__item">
+            <Thumbnail pageNumber={pageIndex + 1} />
+          </li>
+        ))}
       </ul>
     </div>
   );

--- a/ui/library/src/components/thumbnails/ThumbnailList.tsx
+++ b/ui/library/src/components/thumbnails/ThumbnailList.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+
+import { DocumentContext } from '../../context/DocumentContext';
+import { Thumbnail } from './Thumbnail';
+
+type Props = any;
+
+export const ThumbnailList: React.FunctionComponent<Props> = () => {
+  const { numPages } = React.useContext(DocumentContext);
+
+  return (
+    <div className="reader__thumbnail-list">
+      <ul className="reader__thumbnail-list__list">
+        {Array.from({ length: numPages })
+          .map((_, i) => i + 1)
+          .map(pageNumber => (
+            <li key={pageNumber} className="reader__thumbnail-list__item">
+              <Thumbnail pageNumber={pageNumber} />
+            </li>
+          ))}
+      </ul>
+    </div>
+  );
+};

--- a/ui/library/src/context/UiContext.ts
+++ b/ui/library/src/context/UiContext.ts
@@ -9,11 +9,13 @@ export interface IUiContext {
   isShowingHighlightOverlay: boolean;
   isShowingOutline: boolean;
   isShowingTextHighlight: boolean;
+  isShowingThumbnail: boolean;
   setErrorMessage: (errorMessage: Nullable<string>) => void;
   setIsLoading: (isLoading: boolean) => void;
   setIsShowingHighlightOverlay: (isShowingHighlightOverlay: boolean) => void;
   setIsShowingOutline: (isShowingOutline: boolean) => void;
   setIsShowingTextHighlight: (isShowingTextHighlight: boolean) => void;
+  setIsShowingThumbnail: (isShowingThumbnail: boolean) => void;
 }
 
 export const UiContext = React.createContext<IUiContext>({
@@ -22,6 +24,7 @@ export const UiContext = React.createContext<IUiContext>({
   isShowingHighlightOverlay: false,
   isShowingOutline: false,
   isShowingTextHighlight: false,
+  isShowingThumbnail: false,
   setErrorMessage: errorMessage => {
     logProviderWarning(`setErrorMessage(${errorMessage})`, 'UiContext');
   },
@@ -37,6 +40,9 @@ export const UiContext = React.createContext<IUiContext>({
   setIsShowingTextHighlight: isShowingTextHighlight => {
     logProviderWarning(`setIsShowingTextHighlight(${isShowingTextHighlight})`, 'UiContext');
   },
+  setIsShowingThumbnail: isShowingThumbnail => {
+    logProviderWarning(`setIsShowingThumbnail(${isShowingThumbnail})`, 'UiContext');
+  },
 });
 
 export function useUiContextProps(): IUiContext {
@@ -45,6 +51,7 @@ export function useUiContextProps(): IUiContext {
   const [isShowingHighlightOverlay, setIsShowingHighlightOverlay] = React.useState<boolean>(false);
   const [isShowingOutline, setIsShowingOutline] = React.useState<boolean>(false);
   const [isShowingTextHighlight, setIsShowingTextHighlight] = React.useState<boolean>(false);
+  const [isShowingThumbnail, setIsShowingThumbnail] = React.useState<boolean>(false);
 
   return {
     errorMessage,
@@ -52,10 +59,12 @@ export function useUiContextProps(): IUiContext {
     isShowingHighlightOverlay,
     isShowingOutline,
     isShowingTextHighlight,
+    isShowingThumbnail,
     setErrorMessage,
     setIsLoading,
     setIsShowingHighlightOverlay,
     setIsShowingOutline,
     setIsShowingTextHighlight,
+    setIsShowingThumbnail,
   };
 }


### PR DESCRIPTION
## Description

Ref: https://github.com/allenai/scholar/issues/30370
Figma: https://www.figma.com/file/2gUmD3D8tz6gnm9rsYgj6J/Semantic-Reader?node-id=3634%3A37853

This PR adds Thumbnail in PDF Component Library.

## Reviewer Instructions

Create Thumbnail in PDF Component library. Due to the way we render the Outline in PDF Component library is different compare to S2. So i created a button for Thumbnail and when get clicked it will render similar to how Outline does. When input in S2 since it has ReaderSidePanel i can put it in there like how @ctrier has in Figma design.

## Testing Plan

- Verify Thumbnail rendering when you click Thumbnail button
- Verify on hover the page is highlighting 
- Verify if u click a specific page on Thumbnail it should scroll to that page.
- Verify if u on a specific page Thumbnail should highlight that in the list.

## Output / Screenshots

https://user-images.githubusercontent.com/84343285/191814197-bc482dff-d519-4498-80ab-3dba18684bec.mov

### A11y

https://user-images.githubusercontent.com/84343285/191613782-33a5e23a-05ce-4a68-9af8-3810453e859b.mov


