### PR TITLE
Adding tab ability in Thumbnail for Acessibility

### DIFF
--- a/ui/library/src/components/thumbnails/Thumbnail.tsx
+++ b/ui/library/src/components/thumbnails/Thumbnail.tsx
@@ -45,6 +45,7 @@ export const Thumbnail: React.FunctionComponent<Props> = ({ pageNumber }: Props)
   return (
     <a
       aria-label={`scroll to page ${pageNumber}`}
+      href={`#${pageNumber}`}
       onClick={onClick}
       className={classnames(
         'reader__thumbnail',


### PR DESCRIPTION
## Description

Ref: https://github.com/allenai/scholar/issues/30370

Thumbnail cant be tabbed in Semantic Reader so I added href with pageNumber to be able to tab.

## Reviewer Instructions

Adding Tab ability. 

## Testing Plan

Verify user can tab it using keyboard. Other than that yarn format, lint, test

### A11y

https://user-images.githubusercontent.com/84343285/192043301-8a898b98-fb6e-476b-ae33-ab345b7ad5e5.mov




