### PR TITLE
Fix Thumbnail not showing images when user clicks zoom in/out

### DIFF
--- a/ui/library/src/components/thumbnails/Thumbnail.tsx
+++ b/ui/library/src/components/thumbnails/Thumbnail.tsx
@@ -11,7 +11,8 @@ type Props = {
 };
 
 export const Thumbnail: React.FunctionComponent<Props> = ({ pageNumber }: Props) => {
-  const { buildObjectURLForPage, getObjectURLForPage } = React.useContext(PageRenderContext);
+  const { pageRenderStates, buildObjectURLForPage, getObjectURLForPage } =
+    React.useContext(PageRenderContext);
   const { isPageVisible, scrollToPage, visiblePageRatios } = React.useContext(ScrollContext);
   const [maxVisiblePageNumber, setMaxVisiblePageNumber] = React.useState<Nullable<string>>(null);
   const objectURL = getObjectURLForPage({ pageNumber });
@@ -32,7 +33,7 @@ export const Thumbnail: React.FunctionComponent<Props> = ({ pageNumber }: Props)
 
   React.useEffect(() => {
     buildObjectURLForPage({ pageNumber });
-  }, [pageNumber]);
+  }, [pageRenderStates]);
 
   const onClick = React.useCallback(
     event => {


### PR DESCRIPTION
## Description

When user is opening Thumbnail and clicks zoom its not showing the thumbnail with that zoom %. This PR addresses this.

## Reviewer Instructions

It turns in React.useEffect of `Thumbnail.tsx` i should pass pageRenderStates as a dependency instead of pageNumber.

## Testing Plan

Verify when `ThumbnailList` is opening and i click zoom in or out the Thumbnail will be generated again with no issue.

## Output / Screenshots

### Before

https://user-images.githubusercontent.com/84343285/194167017-485ba0a5-63fa-4ae7-a793-3a61b7497558.mov

### After

https://user-images.githubusercontent.com/84343285/194167265-2e0562d5-936b-470a-9cff-9147d7bb4a05.mov

### A11y

N/A