### PR TITLE
create priority queue for loading page objectURLs

### DIFF
--- a/ui/library/src/components/thumbnails/Thumbnail.tsx
+++ b/ui/library/src/components/thumbnails/Thumbnail.tsx
@@ -11,8 +11,7 @@ type Props = {
 };
 
 export const Thumbnail: React.FunctionComponent<Props> = ({ pageNumber }: Props) => {
-  const { pageRenderStates, buildObjectURLForPage, getObjectURLForPage } =
-    React.useContext(PageRenderContext);
+  const { getObjectURLForPage } = React.useContext(PageRenderContext);
   const { isPageVisible, scrollToPage, visiblePageRatios } = React.useContext(ScrollContext);
   const [maxVisiblePageNumber, setMaxVisiblePageNumber] = React.useState<Nullable<string>>(null);
   const objectURL = getObjectURLForPage({ pageNumber });
@@ -30,10 +29,6 @@ export const Thumbnail: React.FunctionComponent<Props> = ({ pageNumber }: Props)
     maxVisiblePageNumber &&
     parseInt(maxVisiblePageNumber) === pageNumber &&
     isPageVisible({ pageNumber });
-
-  React.useEffect(() => {
-    buildObjectURLForPage({ pageNumber });
-  }, [pageRenderStates]);
 
   const onClick = React.useCallback(
     event => {

--- a/ui/library/src/context/PageRenderContext.ts
+++ b/ui/library/src/context/PageRenderContext.ts
@@ -16,6 +16,7 @@ export interface IPageRenderContext {
   pageRenderStates: PageNumberToRenderStateMap;
   getObjectURLForPage: (pageNumber: PageNumber) => Nullable<string>;
   isBuildingObjectURLForPage: (pageNumber: PageNumber) => boolean;
+  isFinishedBuildingAllPagesObjectURLs: () => boolean;
   buildObjectURLForPage: (pageNumber: PageNumber) => Promise<string>;
 }
 
@@ -27,6 +28,10 @@ export const PageRenderContext = React.createContext<IPageRenderContext>({
   },
   isBuildingObjectURLForPage: args => {
     logProviderWarning(`isBuildingObjectURLForPage(${JSON.stringify(args)})`, 'PageRenderContext');
+    return false;
+  },
+  isFinishedBuildingAllPagesObjectURLs: () => {
+    logProviderWarning(`isFinishedBuildingAllPagesObjectURLs()`, 'PageRenderContext');
     return false;
   },
   buildObjectURLForPage: args => {
@@ -81,6 +86,16 @@ export function usePageRenderContextProps({
     },
     [pageRenderStates]
   );
+
+  const isFinishedBuildingAllPagesObjectURLs = React.useCallback((): boolean => {
+    if (!pdfDocProxy) return false;
+    for (let pageNumber = 1; pageNumber <= pdfDocProxy.numPages; pageNumber++) {
+      if (!pageRenderStates.get(pageNumber)?.objectURL) {
+        return false;
+      }
+    }
+    return true;
+  }, [pdfDocProxy, pageRenderStates]);
 
   const getObjectURLForPage = React.useCallback(
     ({ pageNumber, pageIndex }: PageNumber): Nullable<string> => {
@@ -179,6 +194,7 @@ export function usePageRenderContextProps({
     pageRenderStates,
     getObjectURLForPage,
     isBuildingObjectURLForPage,
+    isFinishedBuildingAllPagesObjectURLs,
     buildObjectURLForPage,
   };
 }

--- a/ui/library/src/context/PageRenderContext.ts
+++ b/ui/library/src/context/PageRenderContext.ts
@@ -139,13 +139,26 @@ export function usePageRenderContextProps({
   );
 
   React.useEffect(() => {
-    for (const pageNumber of visiblePageRatios.keys()) {
-      if (pageRenderStates.has(pageNumber)) {
-        continue;
-      }
+    const visiblePages = [...visiblePageRatios.keys()];
+    if (
+      !pdfDocProxy ||
+      [...pageRenderStates.keys()].length === pdfDocProxy.numPages ||
+      visiblePages.length === 0
+    ) {
+      return;
+    }
+
+    const visiblePagesNeighbors = [
+      Math.max(1, visiblePages[0] - 1),
+      Math.min(pdfDocProxy.numPages, visiblePages[visiblePages.length - 1] + 1),
+    ];
+    const allPages = Array.from({ length: pdfDocProxy.numPages }, (_, i) => i + 1);
+    const priorityQueue = new Set([...visiblePages, ...visiblePagesNeighbors, ...allPages]);
+
+    for (const pageNumber of priorityQueue) {
       buildObjectURLForPage({ pageNumber });
     }
-  }, [pageRenderStates, visiblePageRatios]);
+  }, [pageRenderStates, pdfDocProxy, visiblePageRatios]);
 
   // Flush page render states when scale changes
   React.useEffect(() => {


### PR DESCRIPTION
## Description

Creates a priority queue for loading objectURLs for all pages. Previously, we only loaded an objectURL once it was visible in the user viewport. Now, we will load all objectURLs from the start, one at a time. They will be loaded in this order: 1. visible pages 2. neighboring pages to the visible pages 3. every other page

## Reviewer Instructions

## Testing Plan

1. Tested on all browsers
2. Ensured that pages were loaded in the right order

## Output / Screenshots

### Before

https://user-images.githubusercontent.com/108751850/195168031-34aef442-b16a-4da3-b4e5-afd30198bde4.mov

### After

https://user-images.githubusercontent.com/108751850/195167084-9cc385aa-d8ac-4a6c-9222-dea376ea73e3.mov

### A11y

N/A
