### PR TITLE
Fix Page numbers don't update when navigating with thumbnails

### DIFF
--- a/ui/library/src/utils/VisibleEntriesDetector.ts
+++ b/ui/library/src/utils/VisibleEntriesDetector.ts
@@ -1,8 +1,8 @@
 const DEFAULT_ROOT_MARGIN = '50px';
-// This array is a range from 0.0001 to 1 range of threshold. It will help with detecting
-// on scroll with a better % compare to a fix threshold but not firing too frequent that
-// can hamper our performance.
-const DEFAULT_THRESHOLD = [0.0001, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.99];
+// Since recently we run into issue that user scrolls too fast and our PageNumberControl
+// didn't update its accordingly so we increase a threshold (visibility) from
+// 0 to 100% to make it picks up faster.
+const DEFAULT_THRESHOLD = Array.from({ length: 101 }).map((_, i) => i / 100);
 
 export type SetVisibleEntriesCallback<TEntry> = (visible: Map<TEntry, number>) => void;
 export type onVisibleEntriesChangeCallback<TEntry> = (args: {

--- a/ui/library/src/utils/VisibleEntriesDetector.ts
+++ b/ui/library/src/utils/VisibleEntriesDetector.ts
@@ -1,8 +1,6 @@
 const DEFAULT_ROOT_MARGIN = '50px';
-// Since recently we run into issue that user scrolls too fast and our PageNumberControl
-// didn't update its accordingly so we increase a threshold (visibility) from
-// 0 to 100% to make it picks up faster.
-const DEFAULT_THRESHOLD = Array.from({ length: 101 }).map((_, i) => i / 100);
+// It will fire only when it goes out of boundary completely.
+const DEFAULT_THRESHOLD = 1;
 
 export type SetVisibleEntriesCallback<TEntry> = (visible: Map<TEntry, number>) => void;
 export type onVisibleEntriesChangeCallback<TEntry> = (args: {

--- a/ui/library/src/utils/VisibleEntriesDetector.ts
+++ b/ui/library/src/utils/VisibleEntriesDetector.ts
@@ -1,5 +1,5 @@
 const DEFAULT_ROOT_MARGIN = '50px';
-const DEFAULT_THRESHOLD = [0, 0.25, 0.5, 0.75, 1];
+const DEFAULT_THRESHOLD = 0;
 
 export type SetVisibleEntriesCallback<TEntry> = (visible: Map<TEntry, number>) => void;
 export type onVisibleEntriesChangeCallback<TEntry> = (args: {

--- a/ui/library/src/utils/VisibleEntriesDetector.ts
+++ b/ui/library/src/utils/VisibleEntriesDetector.ts
@@ -1,6 +1,5 @@
 const DEFAULT_ROOT_MARGIN = '50px';
-// It will fire only when it goes out of boundary completely.
-const DEFAULT_THRESHOLD = 1;
+const DEFAULT_THRESHOLD = [0, 0.25, 0.5, 0.75, 1];
 
 export type SetVisibleEntriesCallback<TEntry> = (visible: Map<TEntry, number>) => void;
 export type onVisibleEntriesChangeCallback<TEntry> = (args: {


### PR DESCRIPTION
## Description

Ref: https://github.com/allenai/scholar/issues/33968

Since we recently are having issue with PageNumberControl due to user scrolls speed so this PR addresses this.

## Reviewer Instructions

According to the video in the beginning Smita is already at page 15 but the page control is displaying it as page 6 so this can be the case that Smita scrolled faster than IntersectionObserver API picks up the change so that's why our page control can't update accordingly. So i change the threshold to 0 which mean if as soon as a tiny bit of the div is visible, IntersectionObserver will kick in. 

## Testing Plan

Verify when scroll manually through the page, the page number updated accordingly. Also when clicking thumbnail or TOC it will update the page number accordingly.

## Output / Screenshots


Uploading Screen Recording 2022-10-11 at 2.38.11 PM.mov…


### A11y

N/A 