### PR TITLE
Migrate Ingress to use networking.k8s.io/v1 API

### DIFF
--- a/.skiff/webapp.jsonnet
+++ b/.skiff/webapp.jsonnet
@@ -119,7 +119,7 @@ function(
 
     local tls = util.getTLSConfig(fullyQualifiedName, hosts);
     local ingress = {
-        apiVersion: 'extensions/v1beta1',
+        apiVersion: 'networking.k8s.io/v1',
         kind: 'Ingress',
         metadata: {
             name: fullyQualifiedName,
@@ -141,9 +141,15 @@ function(
                     http: {
                         paths: [
                             {
+                                pathType: 'Prefix',
+                                path: '/',
                                 backend: {
-                                    serviceName: fullyQualifiedName,
-                                    servicePort: proxyPort
+                                    service: {
+                                        name: fullyQualifiedName,
+                                        port: {
+                                            number: proxyPort
+                                        }
+                                    }
                                 }
                             }
                         ]


### PR DESCRIPTION
This change updates the Skiff app to use the new (non-deprecated) Kubernetes Ingress API.